### PR TITLE
Fix GitHub Pages: generate root index and API documentation

### DIFF
--- a/.changeset/fix-docgen-documentation.md
+++ b/.changeset/fix-docgen-documentation.md
@@ -1,0 +1,10 @@
+---
+"@evryg/effect-neo4j": patch
+"@evryg/effect-neo4j-schema": patch
+"@evryg/cypher-codegen": patch
+"@evryg/effect-testcontainers": patch
+"@evryg/effect-testcontainers-neo4j": patch
+"@evryg/effect-vitest-neo4j": patch
+---
+
+Fix docgen configuration and add @since JSDoc tags to generate API documentation for GitHub Pages

--- a/packages/cypher-codegen/docgen.json
+++ b/packages/cypher-codegen/docgen.json
@@ -1,6 +1,10 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts",
+    "src/frontend/generated-parser/**/*.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts",
+    "src/**/*.d.cypher.ts"
   ]
 }

--- a/packages/cypher-codegen/src/backend/CypherCodegen.ts
+++ b/packages/cypher-codegen/src/backend/CypherCodegen.ts
@@ -1,8 +1,13 @@
+/** @since 0.0.1 */
 import type { Neo4jType, ResolvedColumn, ResolvedParam } from "../frontend/QueryAnalyzer.js"
 import type { CypherType } from "../types/CypherType.js"
 
 const PARAM_RE = /\$([a-zA-Z_]\w*)/g
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export const extractParams = (cypher: string): ReadonlyArray<string> => {
   const params = new Set<string>()
   for (const match of cypher.matchAll(PARAM_RE)) {
@@ -139,6 +144,10 @@ function tsTypeFor(type: Neo4jType): string {
 
 // ── Module generation ──
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export function generateModule(cypher: string, columns?: ReadonlyArray<ResolvedColumn>): string {
   if (!columns || columns.length === 0) {
     return generateUntypedModule(cypher)
@@ -246,6 +255,10 @@ function toCamelCase(filename: string): string {
   return base.charAt(0).toLowerCase() + base.slice(1) + "Query"
 }
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export interface BarrelEntry {
   readonly filename: string
   readonly cypher: string
@@ -253,6 +266,10 @@ export interface BarrelEntry {
   readonly params: ReadonlyArray<ResolvedParam>
 }
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export function generateBarrel(entries: ReadonlyArray<BarrelEntry>): string {
   const lines: Array<string> = []
 

--- a/packages/cypher-codegen/src/backend/CypherDeclarationGen.ts
+++ b/packages/cypher-codegen/src/backend/CypherDeclarationGen.ts
@@ -1,6 +1,11 @@
+/** @since 0.0.1 */
 import type { Neo4jType, ResolvedColumn, ResolvedParam } from "../frontend/QueryAnalyzer.js"
 import type { CypherType } from "../types/CypherType.js"
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export interface QueryEntry {
   readonly filename: string
   readonly columns: ReadonlyArray<ResolvedColumn>
@@ -75,6 +80,10 @@ function fieldTypeFor(col: ResolvedColumn): string {
 
 // ── Per-file declaration generation (.d.cypher.ts) ──
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export const generateDeclaration = (entry: QueryEntry): string => {
   const lines: Array<string> = []
 
@@ -106,6 +115,10 @@ export const generateDeclaration = (entry: QueryEntry): string => {
 
 // ── Bulk generation (all entries into single file with declare module) ──
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export const generateDeclarations = (queries: ReadonlyArray<QueryEntry>): string => {
   const lines: Array<string> = []
 

--- a/packages/cypher-codegen/src/frontend/InferType.ts
+++ b/packages/cypher-codegen/src/frontend/InferType.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
 import {
   type CypherType,
@@ -18,6 +19,10 @@ import type {
   PropertyExpressionContext
 } from "./generated-parser/CypherParser.js"
 
+/**
+ * @since 0.0.1
+ * @category errors
+ */
 export class CypherTypeError extends Error {
   constructor(message: string) {
     super(message)
@@ -27,6 +32,10 @@ export class CypherTypeError extends Error {
 
 // ── Type environment ──
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export type TypeEnv = ReadonlyMap<string, { readonly type: CypherType; readonly nullable: boolean }>
 
 // ── Schema lookup ──
@@ -150,6 +159,10 @@ const AGGREGATE_RETURN_TYPES: Record<string, CypherType> = {
 
 // ── Recursive expression type inference ──
 
+/**
+ * @since 0.0.1
+ * @category inference
+ */
 export function inferExpressionType(
   expr: ExpressionContext,
   env: TypeEnv,

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
 import { CharStream, CommonTokenStream } from "antlr4ng"
 import * as antlr from "antlr4ng"
@@ -21,6 +22,10 @@ import { inferExpressionType, type TypeEnv } from "./InferType.js"
 // ── Public types ──
 
 // Kept for backward compat with param extraction (params stay flat)
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export type Neo4jType =
   | "String"
   | "Long"
@@ -39,17 +44,29 @@ export type Neo4jType =
   | "BooleanArray"
   | "Unknown"
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface ResolvedColumn {
   readonly name: string
   readonly type: CypherType
   readonly nullable: boolean
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface ResolvedParam {
   readonly name: string
   readonly type: Neo4jType
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface QueryAnalysis {
   readonly columns: ReadonlyArray<ResolvedColumn>
   readonly params: ReadonlyArray<ResolvedParam>
@@ -596,6 +613,10 @@ function extractParams(tree: ReturnType<typeof parse>, schema: GraphSchema): Arr
 
 // ── Public API ──
 
+/**
+ * @since 0.0.1
+ * @category analysis
+ */
 export const analyzeQuery = (cypher: string, schema: GraphSchema): QueryAnalysis => {
   const tree = parse(cypher)
   const singleQuery = tree.query().regularQuery()!.singleQuery()

--- a/packages/cypher-codegen/src/index.ts
+++ b/packages/cypher-codegen/src/index.ts
@@ -1,12 +1,103 @@
-export { extractParams, generateModule } from "./backend/CypherCodegen.js"
-export { generateDeclarations, type QueryEntry } from "./backend/CypherDeclarationGen.js"
-export { CypherTypeError } from "./frontend/InferType.js"
+/**
+ * @since 0.0.1
+ */
 export {
+  /**
+   * @since 0.0.1
+   */
+  extractParams,
+  /**
+   * @since 0.0.1
+   */
+  generateModule
+} from "./backend/CypherCodegen.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  generateDeclarations,
+  /**
+   * @since 0.0.1
+   */
+  type QueryEntry
+} from "./backend/CypherDeclarationGen.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  CypherTypeError
+} from "./frontend/InferType.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
   analyzeQuery,
+  /**
+   * @since 0.0.1
+   */
   type Neo4jType,
+  /**
+   * @since 0.0.1
+   */
   type QueryAnalysis,
+  /**
+   * @since 0.0.1
+   */
   type ResolvedColumn,
+  /**
+   * @since 0.0.1
+   */
   type ResolvedParam
 } from "./frontend/QueryAnalyzer.js"
-export { cypherPlugin } from "./integration/VitePlugin.js"
-export { type CypherType, ListType, MapType, NeverType, ScalarType, UnknownType } from "./types/CypherType.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  cypherPlugin
+} from "./integration/VitePlugin.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  type CypherType,
+  /**
+   * @since 0.0.1
+   */
+  ListType,
+  /**
+   * @since 0.0.1
+   */
+  MapType,
+  /**
+   * @since 0.0.1
+   */
+  NeverType,
+  /**
+   * @since 0.0.1
+   */
+  ScalarType,
+  /**
+   * @since 0.0.1
+   */
+  UnknownType
+} from "./types/CypherType.js"

--- a/packages/cypher-codegen/src/integration/Register.ts
+++ b/packages/cypher-codegen/src/integration/Register.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { NodeContext } from "@effect/platform-node"
 import { type GraphSchema, loadSchema } from "@evryg/effect-neo4j-schema"
 import { Effect } from "effect"

--- a/packages/cypher-codegen/src/integration/VitePlugin.ts
+++ b/packages/cypher-codegen/src/integration/VitePlugin.ts
@@ -1,8 +1,13 @@
+/** @since 0.0.1 */
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
 import { readFileSync } from "node:fs"
 import { generateModule } from "../backend/CypherCodegen.js"
 import { analyzeQuery } from "../frontend/QueryAnalyzer.js"
 
+/**
+ * @since 0.0.1
+ * @category integration
+ */
 export const cypherPlugin = (opts?: { schema?: GraphSchema }) => ({
   name: "vite-plugin-cypher",
   transform(_code: string, id: string) {

--- a/packages/cypher-codegen/src/integration/cli/commands/ApplySchema.ts
+++ b/packages/cypher-codegen/src/integration/cli/commands/ApplySchema.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { Command } from "@effect/cli"
 import { Neo4jClient } from "@evryg/effect-neo4j"
 import { compileToCypherDDL } from "@evryg/effect-neo4j-schema"
@@ -5,6 +6,10 @@ import { Console, Effect } from "effect"
 import type { Schema } from "effect"
 import { neo4jLayer, neo4jOptions } from "./Shared.js"
 
+/**
+ * @since 0.0.1
+ * @category cli
+ */
 export const makeApplySchemaCommand = (allSchemas: Array<Schema.Schema.Any>) =>
   Command.make(
     "apply-schema",

--- a/packages/cypher-codegen/src/integration/cli/commands/ExtractSchema.ts
+++ b/packages/cypher-codegen/src/integration/cli/commands/ExtractSchema.ts
@@ -1,9 +1,14 @@
+/** @since 0.0.1 */
 import { Command } from "@effect/cli"
 import { NodeContext } from "@effect/platform-node"
 import { extractSchema, saveSchema } from "@evryg/effect-neo4j-schema"
 import { Console, Effect } from "effect"
 import { neo4jLayer, neo4jOptions, schemaPathOption } from "./Shared.js"
 
+/**
+ * @since 0.0.1
+ * @category cli
+ */
 export const extractSchemaCommand = Command.make(
   "extract-schema",
   { ...neo4jOptions, schemaPath: schemaPathOption },

--- a/packages/cypher-codegen/src/integration/cli/commands/Generate.ts
+++ b/packages/cypher-codegen/src/integration/cli/commands/Generate.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { Command } from "@effect/cli"
 import { NodeContext } from "@effect/platform-node"
 import { compileToGraphSchema, extractSchema, saveSchema } from "@evryg/effect-neo4j-schema"
@@ -44,6 +45,10 @@ const makeGenerateAnnotationsCommand = (allSchemas: Array<Schema.Schema.Any>) =>
 
 // ── generate (parent) ──
 
+/**
+ * @since 0.0.1
+ * @category cli
+ */
 export const makeGenerateCommand = (allSchemas: Array<Schema.Schema.Any>) =>
   Command.make("generate").pipe(
     Command.withSubcommands([generateLiveDbCommand, makeGenerateAnnotationsCommand(allSchemas)])

--- a/packages/cypher-codegen/src/integration/cli/commands/Shared.ts
+++ b/packages/cypher-codegen/src/integration/cli/commands/Shared.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { Options } from "@effect/cli"
 import { Neo4jConfig, UnconfiguredNeo4jClient } from "@evryg/effect-neo4j"
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
@@ -9,23 +10,55 @@ import { analyzeQuery, type ResolvedParam } from "../../../frontend/QueryAnalyze
 
 // ── Options ──
 
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const neo4jUriOption = Options.withDefault(
   Options.text("neo4j-uri"),
   process.env.NEO4J_URI ?? "bolt://localhost:7687"
 )
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const neo4jUserOption = Options.withDefault(Options.text("neo4j-user"), process.env.NEO4J_USER ?? "neo4j")
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const neo4jPasswordOption = Options.withDefault(
   Options.text("neo4j-password"),
   process.env.NEO4J_PASSWORD ?? "changeme"
 )
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const neo4jDatabaseOption = Options.withDefault(
   Options.text("neo4j-database"),
   process.env.NEO4J_DATABASE ?? "neo4j"
 )
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const schemaPathOption = Options.withDefault(Options.text("schema-path"), "data/graph-schema.json")
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const outputOption = Options.withDefault(Options.text("output"), "src/generated/queries.ts")
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const cypherGlobOption = Options.withDefault(Options.text("cypher-glob"), "src/**/*.cypher")
 
+/**
+ * @since 0.0.1
+ * @category options
+ */
 export const neo4jOptions = {
   neo4jUri: neo4jUriOption,
   neo4jUser: neo4jUserOption,
@@ -35,6 +68,10 @@ export const neo4jOptions = {
 
 // ── Neo4j Layer ──
 
+/**
+ * @since 0.0.1
+ * @category layers
+ */
 export function neo4jLayer(
   opts: { neo4jUri: string; neo4jUser: string; neo4jPassword: string; neo4jDatabase: string }
 ) {
@@ -61,6 +98,10 @@ function mergeParams(analyzerParams: ReadonlyArray<ResolvedParam>, cypher: strin
   return regexNames.filter((n) => byName.has(n)).map((n) => byName.get(n)!)
 }
 
+/**
+ * @since 0.0.1
+ * @category codegen
+ */
 export function generateFromSchema(schema: GraphSchema, output: string, cypherGlob: string) {
   return Effect.gen(function*() {
     const files = globSync(cypherGlob).filter((f) => !basename(f).endsWith("GraphSchema.cypher"))

--- a/packages/cypher-codegen/src/integration/codegen.ts
+++ b/packages/cypher-codegen/src/integration/codegen.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { Command } from "@effect/cli"
 import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
@@ -6,6 +7,10 @@ import { makeApplySchemaCommand } from "./cli/commands/ApplySchema.js"
 import { extractSchemaCommand } from "./cli/commands/ExtractSchema.js"
 import { makeGenerateCommand } from "./cli/commands/Generate.js"
 
+/**
+ * @since 0.0.1
+ * @category cli
+ */
 export function runCodegenCli(allSchemas: Array<Schema.Schema.Any>): void {
   const rootCommand = Command.make("cypher-codegen").pipe(
     Command.withSubcommands([extractSchemaCommand, makeGenerateCommand(allSchemas), makeApplySchemaCommand(allSchemas)])

--- a/packages/cypher-codegen/src/types/CypherType.ts
+++ b/packages/cypher-codegen/src/types/CypherType.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { Schema } from "effect"
 
 // ── Scalar types (no recursion — use Schema.TaggedClass directly) ──
@@ -16,48 +17,92 @@ const ScalarTypeLiteral = Schema.Literal(
   "Point"
 )
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class ScalarType extends Schema.TaggedClass<ScalarType>()("ScalarType", {
   scalarType: ScalarTypeLiteral
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class VertexType extends Schema.TaggedClass<VertexType>()("VertexType", {
   label: Schema.String
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class EdgeType extends Schema.TaggedClass<EdgeType>()("EdgeType", {
   edgeType: Schema.String
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class VertexUnionType extends Schema.TaggedClass<VertexUnionType>()("VertexUnionType", {
   labels: Schema.Array(Schema.String)
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class UnknownType extends Schema.TaggedClass<UnknownType>()("UnknownType", {}) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class NeverType extends Schema.TaggedClass<NeverType>()("NeverType", {}) {}
 
 // ── Recursive types (interface-first to break circularity) ──
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface ListType {
   readonly _tag: "ListType"
   readonly element: CypherType
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface MapField {
   readonly name: string
   readonly value: CypherType
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface MapType {
   readonly _tag: "MapType"
   readonly fields: ReadonlyArray<MapField>
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface NullableType {
   readonly _tag: "NullableType"
   readonly inner: CypherType
 }
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export type CypherType =
   | ScalarType
   | ListType
@@ -71,16 +116,28 @@ export type CypherType =
 
 // ── Constructors for recursive variants ──
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const ListType = (element: CypherType): ListType => ({
   _tag: "ListType" as const,
   element
 })
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const MapType = (fields: ReadonlyArray<MapField>): MapType => ({
   _tag: "MapType" as const,
   fields
 })
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const NullableType = (inner: CypherType): NullableType => ({
   _tag: "NullableType" as const,
   inner
@@ -88,7 +145,11 @@ export const NullableType = (inner: CypherType): NullableType => ({
 
 // ── Schema (for encode/decode if needed) ──
 
-const CypherTypeSchema: Schema.Schema<CypherType> = Schema.Union(
+/**
+ * @since 0.0.1
+ * @category schema
+ */
+export const CypherTypeSchema: Schema.Schema<CypherType> = Schema.Union(
   ScalarType,
   Schema.Struct({
     _tag: Schema.Literal("ListType"),
@@ -111,4 +172,3 @@ const CypherTypeSchema: Schema.Schema<CypherType> = Schema.Union(
   UnknownType,
   NeverType
 )
-export { CypherTypeSchema }

--- a/packages/neo4j-schema/docgen.json
+++ b/packages/neo4j-schema/docgen.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts"
   ]
 }

--- a/packages/neo4j-schema/src/GraphSchemaModel.ts
+++ b/packages/neo4j-schema/src/GraphSchemaModel.ts
@@ -1,8 +1,15 @@
+/**
+ * @since 0.0.1
+ */
 import { FileSystem } from "@effect/platform"
 import { Effect, Schema } from "effect"
 
 // ── DDD Subdomain models --
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class VertexProperty extends Schema.Class<VertexProperty>("VertexProperty")({
   labels: Schema.Array(Schema.String),
   propertyName: Schema.String,
@@ -10,6 +17,10 @@ export class VertexProperty extends Schema.Class<VertexProperty>("VertexProperty
   mandatory: Schema.Boolean
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class EdgeProperty extends Schema.Class<EdgeProperty>("EdgeProperty")({
   edgeType: Schema.String,
   propertyName: Schema.String,
@@ -17,12 +28,20 @@ export class EdgeProperty extends Schema.Class<EdgeProperty>("EdgeProperty")({
   mandatory: Schema.Boolean
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class EdgeConnectivity extends Schema.Class<EdgeConnectivity>("EdgeConnectivity")({
   edgeType: Schema.String,
   fromLabel: Schema.String,
   toLabel: Schema.String
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class GraphSchema extends Schema.Class<GraphSchema>("GraphSchema")({
   vertexProperties: Schema.Array(VertexProperty),
   edgeProperties: Schema.Array(EdgeProperty),
@@ -34,9 +53,17 @@ export class GraphSchema extends Schema.Class<GraphSchema>("GraphSchema")({
 const encodeSchema = Schema.encodeSync(GraphSchema)
 const decodeSchema = Schema.decodeSync(GraphSchema)
 
+/**
+ * @since 0.0.1
+ * @category utils
+ */
 export const saveSchema = (path: string, schema: GraphSchema) =>
   Effect.flatMap(FileSystem.FileSystem, (fs) => fs.writeFileString(path, JSON.stringify(encodeSchema(schema), null, 2)))
 
+/**
+ * @since 0.0.1
+ * @category utils
+ */
 export const loadSchema = (path: string) =>
   Effect.flatMap(
     FileSystem.FileSystem,

--- a/packages/neo4j-schema/src/GraphSchemaResolver.ts
+++ b/packages/neo4j-schema/src/GraphSchemaResolver.ts
@@ -1,7 +1,14 @@
+/**
+ * @since 0.0.1
+ */
 import type { Effect } from "effect"
 import { Context } from "effect"
 import type { GraphSchema } from "./GraphSchemaModel.js"
 
+/**
+ * @since 0.0.1
+ * @category resolvers
+ */
 export class GraphSchemaResolver extends Context.Tag("GraphSchemaResolver")<
   GraphSchemaResolver,
   { readonly resolve: Effect.Effect<GraphSchema> }

--- a/packages/neo4j-schema/src/Neo4jSchemaAnnotations.ts
+++ b/packages/neo4j-schema/src/Neo4jSchemaAnnotations.ts
@@ -1,16 +1,31 @@
+/**
+ * @since 0.0.1
+ */
 import type { Schema } from "effect"
 
 // ── Field-level annotations ──
 
-/** Mark a property as UNIQUE constraint in Neo4j */
+/**
+ * Mark a property as UNIQUE constraint in Neo4j
+ * @since 0.0.1
+ * @category annotations
+ */
 export const neo4jUnique = { neo4jUnique: true as const }
 
-/** Mark a property for index creation in Neo4j */
+/**
+ * Mark a property for index creation in Neo4j
+ * @since 0.0.1
+ * @category annotations
+ */
 export const neo4jIndexed = { neo4jIndex: true as const }
 
 // ── Struct-level annotations ──
 
-/** Annotate an Effect Schema struct as a Neo4j vertex (node) */
+/**
+ * Annotate an Effect Schema struct as a Neo4j vertex (node)
+ * @since 0.0.1
+ * @category annotations
+ */
 export const neo4jVertex = (
   label: string,
   opts?: {
@@ -29,7 +44,11 @@ function extractNeo4jLabel(vertexSchema: Schema.Schema.Any): string {
   return label
 }
 
-/** Annotate an Effect Schema struct as a Neo4j edge (relationship) */
+/**
+ * Annotate an Effect Schema struct as a Neo4j edge (relationship)
+ * @since 0.0.1
+ * @category annotations
+ */
 export const neo4jEdge = (
   edgeType: string,
   connectivity?: ReadonlyArray<{ from: Schema.Schema.Any; to: Schema.Schema.Any }>

--- a/packages/neo4j-schema/src/Neo4jSchemaDDL.ts
+++ b/packages/neo4j-schema/src/Neo4jSchemaDDL.ts
@@ -1,6 +1,13 @@
+/**
+ * @since 0.0.1
+ */
 import type { Schema } from "effect"
 
-/** Compile Effect Schema structs with neo4j annotations into Cypher DDL statements */
+/**
+ * Compile Effect Schema structs with neo4j annotations into Cypher DDL statements
+ * @since 0.0.1
+ * @category ddl
+ */
 export function compileToCypherDDL(schemas: Array<Schema.Schema.Any>): string {
   const lines: Array<string> = []
 

--- a/packages/neo4j-schema/src/index.ts
+++ b/packages/neo4j-schema/src/index.ts
@@ -1,16 +1,94 @@
+/**
+ * @since 0.0.1
+ */
 export {
+  /**
+   * @since 0.0.1
+   */
   EdgeConnectivity,
+  /**
+   * @since 0.0.1
+   */
   EdgeProperty,
+  /**
+   * @since 0.0.1
+   */
   GraphSchema,
+  /**
+   * @since 0.0.1
+   */
   loadSchema,
+  /**
+   * @since 0.0.1
+   */
   saveSchema,
+  /**
+   * @since 0.0.1
+   */
   VertexProperty
 } from "./GraphSchemaModel.js"
-export { GraphSchemaResolver } from "./GraphSchemaResolver.js"
-export { neo4jEdge, neo4jIndexed, neo4jUnique, neo4jVertex } from "./Neo4jSchemaAnnotations.js"
-export { compileToCypherDDL } from "./Neo4jSchemaDDL.js"
+/**
+ * @since 0.0.1
+ */
 export {
+  /**
+   * @since 0.0.1
+   */
+  GraphSchemaResolver
+} from "./GraphSchemaResolver.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  neo4jEdge,
+  /**
+   * @since 0.0.1
+   */
+  neo4jIndexed,
+  /**
+   * @since 0.0.1
+   */
+  neo4jUnique,
+  /**
+   * @since 0.0.1
+   */
+  neo4jVertex
+} from "./Neo4jSchemaAnnotations.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  compileToCypherDDL
+} from "./Neo4jSchemaDDL.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
   AnnotationGraphSchemaResolver,
+  /**
+   * @since 0.0.1
+   */
   compileToGraphSchema
 } from "./resolvers/annotation/AnnotationGraphSchemaResolver.js"
-export { extractSchema, LiveDbGraphSchemaResolver } from "./resolvers/live_db/LiveDbGraphSchemaResolver.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  extractSchema,
+  /**
+   * @since 0.0.1
+   */
+  LiveDbGraphSchemaResolver
+} from "./resolvers/live_db/LiveDbGraphSchemaResolver.js"

--- a/packages/neo4j-schema/src/resolvers/annotation/AnnotationGraphSchemaResolver.ts
+++ b/packages/neo4j-schema/src/resolvers/annotation/AnnotationGraphSchemaResolver.ts
@@ -1,3 +1,6 @@
+/**
+ * @since 0.0.1
+ */
 import { Effect, Layer } from "effect"
 import type { Schema } from "effect"
 import { EdgeConnectivity, EdgeProperty, GraphSchema, VertexProperty } from "../../GraphSchemaModel.js"
@@ -39,7 +42,11 @@ function unwrapOptional(ast: any): any {
 
 // ── Schema compilation ──
 
-/** Compile Effect Schema structs with neo4j annotations into a GraphSchema for query validation */
+/**
+ * Compile Effect Schema structs with neo4j annotations into a GraphSchema for query validation
+ * @since 0.0.1
+ * @category constructors
+ */
 export function compileToGraphSchema(schemas: Array<Schema.Schema.Any>): GraphSchema {
   const vertexProperties: Array<VertexProperty> = []
   const edgeProperties: Array<EdgeProperty> = []
@@ -99,6 +106,10 @@ export function compileToGraphSchema(schemas: Array<Schema.Schema.Any>): GraphSc
 
 // ── Layer ──
 
+/**
+ * @since 0.0.1
+ * @category resolvers
+ */
 export const AnnotationGraphSchemaResolver = (
   schemas: Array<Schema.Schema.Any>
 ): Layer.Layer<GraphSchemaResolver> =>

--- a/packages/neo4j-schema/src/resolvers/live_db/LiveDbGraphSchemaResolver.ts
+++ b/packages/neo4j-schema/src/resolvers/live_db/LiveDbGraphSchemaResolver.ts
@@ -1,16 +1,39 @@
+/**
+ * @since 0.0.1
+ */
 import { Neo4jClient, type Neo4jQueryError } from "@evryg/effect-neo4j"
 import { Effect, Layer, Schema } from "effect"
 import { EdgeConnectivity, EdgeProperty, GraphSchema, VertexProperty } from "../../GraphSchemaModel.js"
 import { GraphSchemaResolver } from "../../GraphSchemaResolver.js"
 
 // Re-export models so existing imports work
-export { EdgeProperty, GraphSchema, VertexProperty } from "../../GraphSchemaModel.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  EdgeProperty,
+  /**
+   * @since 0.0.1
+   */
+  GraphSchema,
+  /**
+   * @since 0.0.1
+   */
+  VertexProperty
+} from "../../GraphSchemaModel.js"
 
 // ── Extraction from Neo4j ──
 
 const decodeVertexProperty = Schema.decodeUnknownSync(VertexProperty)
 const decodeEdgeProperty = Schema.decodeUnknownSync(EdgeProperty)
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const extractSchema = (): Effect.Effect<GraphSchema, Neo4jQueryError, Neo4jClient> =>
   Effect.flatMap(Neo4jClient, (neo4j) =>
     Effect.gen(function*() {
@@ -62,6 +85,10 @@ export const extractSchema = (): Effect.Effect<GraphSchema, Neo4jQueryError, Neo
 
 // ── Layer ──
 
+/**
+ * @since 0.0.1
+ * @category resolvers
+ */
 export const LiveDbGraphSchemaResolver: Layer.Layer<GraphSchemaResolver, never, Neo4jClient> = Layer.effect(
   GraphSchemaResolver,
   Effect.map(Neo4jClient, () => ({

--- a/packages/neo4j/docgen.json
+++ b/packages/neo4j/docgen.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts"
   ]
 }

--- a/packages/neo4j/src/Neo4jClient.ts
+++ b/packages/neo4j/src/Neo4jClient.ts
@@ -1,41 +1,86 @@
+/**
+ * @since 0.0.1
+ */
 import { Context, Effect, Layer, Schema, Stream } from "effect"
-import neo4j, { type Driver, type QueryResult, type Record as Neo4jRecord, type Session } from "neo4j-driver"
+import neo4j, { type Driver, type QueryResult, type Record as Neo4jRecord_, type Session } from "neo4j-driver"
 import { Neo4jConfig } from "./Neo4jConfig.js"
 
-export type { Record as Neo4jRecord } from "neo4j-driver"
+/**
+ * A record returned from a Neo4j query.
+ *
+ * @since 0.0.1
+ * @category models
+ */
+export type Neo4jRecord = Neo4jRecord_
 
 // --- Errors ---
 
+/**
+ * @since 0.0.1
+ * @category errors
+ */
 export class Neo4jConnectionError extends Schema.TaggedError<Neo4jConnectionError>()("Neo4jConnectionError", {
   uri: Schema.String,
   cause: Schema.Defect
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category errors
+ */
 export class Neo4jQueryError extends Schema.TaggedError<Neo4jQueryError>()("Neo4jQueryError", {
   cypher: Schema.String,
   cause: Schema.Defect
 }) {}
 
+/**
+ * @since 0.0.1
+ * @category errors
+ */
 export type Neo4jError = Neo4jConnectionError | Neo4jQueryError
 
 // --- Effectful combinators ---
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const makeDriver = (uri: string, user: string, password: string): Effect.Effect<Driver> =>
   Effect.sync(() => neo4j.driver(uri, neo4j.auth.basic(user, password)))
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const closeDriver = (driver: Driver): Effect.Effect<void> => Effect.promise(() => driver.close())
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const verifyDriver = (driver: Driver, uri: string): Effect.Effect<void, Neo4jConnectionError> =>
   Effect.tryPromise({
     try: () => driver.verifyConnectivity(),
     catch: (e) => new Neo4jConnectionError({ uri, cause: e })
   })
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const openSession = (driver: Driver, database: string): Effect.Effect<Session> =>
   Effect.sync(() => driver.session({ database }))
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const closeSession = (session: Session): Effect.Effect<void> => Effect.promise(() => session.close())
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const runCypher = (
   session: Session,
   cypher: string,
@@ -46,6 +91,10 @@ export const runCypher = (
     catch: (e) => new Neo4jQueryError({ cypher, cause: e })
   })
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const runCypherWrite = (
   session: Session,
   cypher: string,
@@ -58,6 +107,10 @@ export const runCypherWrite = (
 
 // --- Service ---
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export class Neo4jClient extends Context.Tag("Neo4jClient")<Neo4jClient, {
   readonly query: (
     cypher: string,
@@ -74,6 +127,10 @@ export class Neo4jClient extends Context.Tag("Neo4jClient")<Neo4jClient, {
   ) => Effect.Effect<number, Neo4jQueryError>
 }>() {}
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const UnconfiguredNeo4jClient: Layer.Layer<Neo4jClient, never, Neo4jConfig> = Layer.scoped(
   Neo4jClient,
   Effect.gen(function*() {

--- a/packages/neo4j/src/Neo4jConfig.ts
+++ b/packages/neo4j/src/Neo4jConfig.ts
@@ -1,5 +1,12 @@
+/**
+ * @since 0.0.1
+ */
 import { Context } from "effect"
 
+/**
+ * @since 0.0.1
+ * @category config
+ */
 export class Neo4jConfig extends Context.Tag("Neo4jConfig")<Neo4jConfig, {
   readonly uri: string
   readonly user: string
@@ -7,4 +14,8 @@ export class Neo4jConfig extends Context.Tag("Neo4jConfig")<Neo4jConfig, {
   readonly database: string
 }>() {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export type Neo4jConnectionConfig = Context.Tag.Service<typeof Neo4jConfig>

--- a/packages/neo4j/src/Neo4jSchemas.ts
+++ b/packages/neo4j/src/Neo4jSchemas.ts
@@ -1,9 +1,15 @@
+/**
+ * @since 0.0.1
+ */
 import { Schema } from "effect"
 import { isInt } from "neo4j-driver"
 
 /**
  * Schema transform that decodes a Neo4j Integer (or plain JS number) to a JS number.
  * Use for columns typed as Long in the Cypher query analyzer.
+ *
+ * @since 0.0.1
+ * @category schemas
  */
 export const Neo4jInt: Schema.Schema<number, unknown> = Schema.transform(
   Schema.Unknown,
@@ -17,6 +23,7 @@ export const Neo4jInt: Schema.Schema<number, unknown> = Schema.transform(
 /**
  * Recursively coerces Neo4j driver types (Integer objects) to plain JS primitives.
  * Use for columns typed as Unknown in the Cypher query analyzer.
+ * @internal
  */
 function coerce(v: unknown): unknown {
   if (v === null || v === undefined) return v
@@ -30,6 +37,10 @@ function coerce(v: unknown): unknown {
   return v
 }
 
+/**
+ * @since 0.0.1
+ * @category schemas
+ */
 export const Neo4jValue: Schema.Schema<unknown, unknown> = Schema.transform(
   Schema.Unknown,
   Schema.Unknown,

--- a/packages/neo4j/src/SchemaFragment.ts
+++ b/packages/neo4j/src/SchemaFragment.ts
@@ -1,8 +1,19 @@
+/**
+ * @since 0.0.1
+ */
 import { Effect } from "effect"
 import { Neo4jClient } from "./Neo4jClient.js"
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export type SchemaFragment = ReadonlyArray<string>
 
+/**
+ * @since 0.0.1
+ * @category combinators
+ */
 export const ensureSchema = (
   fragments: Array<SchemaFragment>
 ): Effect.Effect<void, Error, Neo4jClient> =>

--- a/packages/neo4j/src/VerifyNeo4j.ts
+++ b/packages/neo4j/src/VerifyNeo4j.ts
@@ -1,8 +1,15 @@
+/**
+ * @since 0.0.1
+ */
 import { Effect } from "effect"
 import { closeDriver, makeDriver, verifyDriver } from "./Neo4jClient.js"
 import type { Neo4jConnectionError } from "./Neo4jClient.js"
 import type { Neo4jConnectionConfig } from "./Neo4jConfig.js"
 
+/**
+ * @since 0.0.1
+ * @category utils
+ */
 export function verifyNeo4j(
   config: Neo4jConnectionConfig
 ): Effect.Effect<void, Neo4jConnectionError> {

--- a/packages/neo4j/src/index.ts
+++ b/packages/neo4j/src/index.ts
@@ -1,19 +1,105 @@
+/**
+ * @since 0.0.1
+ */
 export {
+  /**
+   * @since 0.0.1
+   */
   closeDriver,
+  /**
+   * @since 0.0.1
+   */
   closeSession,
+  /**
+   * @since 0.0.1
+   */
   makeDriver,
+  /**
+   * @since 0.0.1
+   */
   Neo4jClient,
+  /**
+   * @since 0.0.1
+   */
   Neo4jConnectionError,
+  /**
+   * @since 0.0.1
+   */
   type Neo4jError,
+  /**
+   * @since 0.0.1
+   */
   Neo4jQueryError,
+  /**
+   * @since 0.0.1
+   */
   type Neo4jRecord,
+  /**
+   * @since 0.0.1
+   */
   openSession,
+  /**
+   * @since 0.0.1
+   */
   runCypher,
+  /**
+   * @since 0.0.1
+   */
   runCypherWrite,
+  /**
+   * @since 0.0.1
+   */
   UnconfiguredNeo4jClient,
+  /**
+   * @since 0.0.1
+   */
   verifyDriver
 } from "./Neo4jClient.js"
-export { Neo4jConfig, type Neo4jConnectionConfig } from "./Neo4jConfig.js"
-export { Neo4jInt, Neo4jValue } from "./Neo4jSchemas.js"
-export { ensureSchema, type SchemaFragment } from "./SchemaFragment.js"
-export { verifyNeo4j } from "./VerifyNeo4j.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  Neo4jConfig,
+  /**
+   * @since 0.0.1
+   */
+  type Neo4jConnectionConfig
+} from "./Neo4jConfig.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  Neo4jInt,
+  /**
+   * @since 0.0.1
+   */
+  Neo4jValue
+} from "./Neo4jSchemas.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  ensureSchema,
+  /**
+   * @since 0.0.1
+   */
+  type SchemaFragment
+} from "./SchemaFragment.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  verifyNeo4j
+} from "./VerifyNeo4j.js"

--- a/packages/testcontainers-neo4j/docgen.json
+++ b/packages/testcontainers-neo4j/docgen.json
@@ -1,6 +1,8 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test-d.ts"
   ]
 }

--- a/packages/testcontainers-neo4j/src/Neo4jTestContainer.ts
+++ b/packages/testcontainers-neo4j/src/Neo4jTestContainer.ts
@@ -1,13 +1,24 @@
+/**
+ * @since 0.0.1
+ */
 import { Neo4jConfig } from "@evryg/effect-neo4j"
 import { acquireContainer } from "@evryg/effect-testcontainers"
 import { Neo4jContainer } from "@testcontainers/neo4j"
 import { Effect, Layer } from "effect"
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface Neo4jTestContainerOptions {
   readonly image?: string
   readonly password?: string
 }
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const makeNeo4jTestContainer = (
   opts?: Neo4jTestContainerOptions
 ): Layer.Layer<Neo4jConfig, Error> => {
@@ -26,4 +37,8 @@ export const makeNeo4jTestContainer = (
   )
 }
 
+/**
+ * @since 0.0.1
+ * @category containers
+ */
 export const Neo4jTestContainerLive: Layer.Layer<Neo4jConfig, Error> = makeNeo4jTestContainer()

--- a/packages/testcontainers-neo4j/src/index.ts
+++ b/packages/testcontainers-neo4j/src/index.ts
@@ -1,1 +1,17 @@
-export { makeNeo4jTestContainer, Neo4jTestContainerLive, type Neo4jTestContainerOptions } from "./Neo4jTestContainer.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  makeNeo4jTestContainer,
+  /**
+   * @since 0.0.1
+   */
+  Neo4jTestContainerLive,
+  /**
+   * @since 0.0.1
+   */
+  type Neo4jTestContainerOptions
+} from "./Neo4jTestContainer.js"

--- a/packages/testcontainers/docgen.json
+++ b/packages/testcontainers/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts"
   ]
 }

--- a/packages/testcontainers/src/ComposeContainer.ts
+++ b/packages/testcontainers/src/ComposeContainer.ts
@@ -1,12 +1,23 @@
+/**
+ * @since 0.0.1
+ */
 import { Context, Effect, Layer } from "effect"
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from "testcontainers"
 import type { ComposeExecutableOptions } from "testcontainers/build/container-runtime"
 
+/**
+ * @since 0.0.1
+ * @category containers
+ */
 export class ComposeEnvironment extends Context.Tag("ComposeEnvironment")<
   ComposeEnvironment,
   StartedDockerComposeEnvironment
 >() {}
 
+/**
+ * @since 0.0.1
+ * @category models
+ */
 export interface ComposeOptions {
   readonly composeFilePath: string
   readonly composeFile: string
@@ -14,6 +25,10 @@ export interface ComposeOptions {
   readonly executable?: ComposeExecutableOptions
 }
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const makeComposeContainer = (
   opts: ComposeOptions
 ): Layer.Layer<ComposeEnvironment, Error> =>

--- a/packages/testcontainers/src/TestContainer.ts
+++ b/packages/testcontainers/src/TestContainer.ts
@@ -1,7 +1,14 @@
+/**
+ * @since 0.0.1
+ */
 import type { Scope } from "effect"
 import { Effect } from "effect"
 import type { StartedTestContainer } from "testcontainers"
 
+/**
+ * @since 0.0.1
+ * @category constructors
+ */
 export const acquireContainer = <C extends StartedTestContainer>(
   start: () => Promise<C>
 ): Effect.Effect<C, Error, Scope.Scope> =>

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -1,2 +1,27 @@
-export { ComposeEnvironment, type ComposeOptions, makeComposeContainer } from "./ComposeContainer.js"
-export { acquireContainer } from "./TestContainer.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  ComposeEnvironment,
+  /**
+   * @since 0.0.1
+   */
+  type ComposeOptions,
+  /**
+   * @since 0.0.1
+   */
+  makeComposeContainer
+} from "./ComposeContainer.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  acquireContainer
+} from "./TestContainer.js"

--- a/packages/vitest-neo4j/docgen.json
+++ b/packages/vitest-neo4j/docgen.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/@effect/docgen/schema.json",
   "exclude": [
-    "src/**"
+    "src/internal/**/*.ts"
   ]
 }

--- a/packages/vitest-neo4j/src/CleanNeo4jGraph.ts
+++ b/packages/vitest-neo4j/src/CleanNeo4jGraph.ts
@@ -1,7 +1,13 @@
+/** @since 0.0.1 */
 import { Neo4jClient } from "@evryg/effect-neo4j"
 import { Effect } from "effect"
 
-/** Scoped resource: clears all nodes/edges on acquire. Use with `it.scoped`. */
+/**
+ * Scoped resource: clears all nodes/edges on acquire. Use with `it.scoped`.
+ *
+ * @since 0.0.1
+ * @category utils
+ */
 export const CleanNeo4jGraph = Effect.acquireRelease(
   Effect.flatMap(Neo4jClient, (neo4j) => neo4j.query("MATCH (n) DETACH DELETE n")),
   () => Effect.void

--- a/packages/vitest-neo4j/src/Neo4jConfigFromVitest.ts
+++ b/packages/vitest-neo4j/src/Neo4jConfigFromVitest.ts
@@ -1,7 +1,12 @@
+/** @since 0.0.1 */
 import { Neo4jConfig } from "@evryg/effect-neo4j"
 import { Layer } from "effect"
 import { inject } from "vitest"
 
+/**
+ * @since 0.0.1
+ * @category config
+ */
 export const Neo4jConfigFromVitest: Layer.Layer<Neo4jConfig> = Layer.succeed(Neo4jConfig, {
   uri: inject("neo4j").uri,
   user: "neo4j",

--- a/packages/vitest-neo4j/src/index.ts
+++ b/packages/vitest-neo4j/src/index.ts
@@ -1,2 +1,19 @@
-export { CleanNeo4jGraph } from "./CleanNeo4jGraph.js"
-export { Neo4jConfigFromVitest } from "./Neo4jConfigFromVitest.js"
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  CleanNeo4jGraph
+} from "./CleanNeo4jGraph.js"
+
+/**
+ * @since 0.0.1
+ */
+export {
+  /**
+   * @since 0.0.1
+   */
+  Neo4jConfigFromVitest
+} from "./Neo4jConfigFromVitest.js"

--- a/packages/vitest-neo4j/src/neo4j-global-setup.ts
+++ b/packages/vitest-neo4j/src/neo4j-global-setup.ts
@@ -1,3 +1,4 @@
+/** @since 0.0.1 */
 import { ensureSchema, Neo4jConfig, UnconfiguredNeo4jClient } from "@evryg/effect-neo4j"
 import { Neo4jTestContainerLive } from "@evryg/effect-testcontainers-neo4j"
 import { Layer, ManagedRuntime } from "effect"
@@ -21,11 +22,19 @@ const TestNeo4jLive = SchemaSetupLive.pipe(
 
 const runtime = ManagedRuntime.make(TestNeo4jLive)
 
+/**
+ * @since 0.0.1
+ * @category setup
+ */
 export async function setup({ provide }: GlobalSetupContext) {
   const config = await runtime.runPromise(Neo4jConfig)
   provide("neo4j", { uri: config.uri, password: config.password })
 }
 
+/**
+ * @since 0.0.1
+ * @category setup
+ */
 export async function teardown() {
   await runtime.dispose()
 }

--- a/scripts/docs.mjs
+++ b/scripts/docs.mjs
@@ -61,3 +61,18 @@ packages().forEach((pkg, i) => {
   copyFiles(pkg)
   generateIndex(pkg, i + 2)
 })
+
+// Generate root index
+Fs.writeFileSync(
+  Path.join("docs", "index.md"),
+  `---
+title: Home
+nav_order: 1
+permalink: /
+---
+
+# @evryg/effect-contrib
+
+API documentation for the @evryg/effect-contrib packages.
+`
+)


### PR DESCRIPTION
## Summary
- Generate a root `index.md` in the docgen script so GitHub Pages has a landing page at `/`
- Fix `docgen.json` in all packages: change `exclude: ["src/**"]` to `exclude: ["src/internal/**/*.ts"]` — the blanket exclude was preventing all documentation from being generated
- Exclude test files (`*.test.ts`, `*.test-d.ts`) and generated parser files from docgen
- Add `@since 0.0.1` JSDoc tags and `@category` annotations to all exported members, matching `effect-ts/effect` conventions
- Add module-level `@since` JSDoc and per-symbol `@since` on re-exports
- Add changeset for all affected packages

## Packages affected
- `@evryg/effect-neo4j`
- `@evryg/effect-neo4j-schema`
- `@evryg/cypher-codegen`
- `@evryg/effect-testcontainers`
- `@evryg/effect-testcontainers-neo4j`
- `@evryg/effect-vitest-neo4j`

## Test plan
- [x] `pnpm docgen` succeeds and generates docs with actual API content
- [x] `pnpm check` passes
- [ ] Pages workflow passes on this branch
- [ ] After merge, https://evryg-org.github.io/effect-contrib/ loads with content