### PR TITLE
Fix package dependency declarations

### DIFF
--- a/.changeset/fix-package-dependency-declarations.md
+++ b/.changeset/fix-package-dependency-declarations.md
@@ -1,0 +1,14 @@
+---
+"@evryg/effect-testcontainers-neo4j": patch
+"@evryg/effect-cypher-codegen": patch
+"@evryg/effect-testcontainers": patch
+"@evryg/effect-neo4j-schema": patch
+"@evryg/effect-vitest-neo4j": patch
+---
+
+Fix package dependency declarations
+
+- Use workspace:^ instead of workspace:* for internal cross-package references
+- Add missing vitest peer dependency to @evryg/effect-vitest-neo4j
+- Remove unused neo4j-driver-core peer dependency from @evryg/effect-vitest-neo4j
+- Inline ComposeExecutableOptions type to remove internal testcontainers import path

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@effect/dtslint": "^0.1.1",
     "@effect/eslint-plugin": "^0.2.0",
     "@effect/language-service": "^0.1.0",
-    "@effect/vitest": "^0.12.1",
+    "@effect/vitest": "^0.29.0",
     "@eslint/compat": "1.1.1",
     "@eslint/eslintrc": "3.1.0",
     "@eslint/js": "9.9.1",

--- a/packages/cypher-codegen/package.json
+++ b/packages/cypher-codegen/package.json
@@ -57,6 +57,6 @@
     "@evryg/effect-vitest-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "neo4j-driver": "^6.0.1",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/cypher-codegen/package.json
+++ b/packages/cypher-codegen/package.json
@@ -37,8 +37,8 @@
     "coverage": "vitest --coverage"
   },
   "dependencies": {
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-neo4j-schema": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-neo4j-schema": "workspace:^",
     "antlr4ng": "^3.0.16"
   },
   "peerDependencies": {
@@ -54,7 +54,7 @@
     "@effect/platform": "^0.96.0",
     "@effect/platform-node": "^0.106.0",
     "@effect/vitest": "^0.29.0",
-    "@evryg/effect-vitest-neo4j": "workspace:*",
+    "@evryg/effect-vitest-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "neo4j-driver": "^6.0.1",
     "vitest": "^3.2.1"

--- a/packages/neo4j-schema/package.json
+++ b/packages/neo4j-schema/package.json
@@ -35,15 +35,15 @@
   },
   "peerDependencies": {
     "@effect/platform": "^0.96.0",
-    "@evryg/effect-neo4j": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
     "effect": "^3.21.0"
   },
   "devDependencies": {
     "@effect/platform": "^0.96.0",
     "@effect/platform-node": "^0.106.0",
     "@effect/vitest": "^0.29.0",
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-vitest-neo4j": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-vitest-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "fast-check": "^3.23.2",
     "vitest": "^3.2.1"

--- a/packages/neo4j-schema/package.json
+++ b/packages/neo4j-schema/package.json
@@ -46,6 +46,6 @@
     "@evryg/effect-vitest-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "fast-check": "^3.23.2",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/neo4j/package.json
+++ b/packages/neo4j/package.json
@@ -41,6 +41,6 @@
     "@effect/vitest": "^0.29.0",
     "effect": "^3.21.0",
     "neo4j-driver": "^6.0.1",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/testcontainers-neo4j/package.json
+++ b/packages/testcontainers-neo4j/package.json
@@ -34,15 +34,15 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-testcontainers": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-testcontainers": "workspace:^",
     "@testcontainers/neo4j": "^11.12.0",
     "effect": "^3.21.0"
   },
   "devDependencies": {
     "@effect/vitest": "^0.29.0",
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-testcontainers": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-testcontainers": "workspace:^",
     "@testcontainers/neo4j": "^11.12.0",
     "effect": "^3.21.0",
     "vitest": "^3.2.1"

--- a/packages/testcontainers-neo4j/package.json
+++ b/packages/testcontainers-neo4j/package.json
@@ -45,6 +45,6 @@
     "@evryg/effect-testcontainers": "workspace:^",
     "@testcontainers/neo4j": "^11.12.0",
     "effect": "^3.21.0",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/testcontainers/package.json
+++ b/packages/testcontainers/package.json
@@ -40,6 +40,6 @@
   "devDependencies": {
     "effect": "^3.21.0",
     "testcontainers": "^11.12.0",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/testcontainers/src/ComposeContainer.ts
+++ b/packages/testcontainers/src/ComposeContainer.ts
@@ -3,7 +3,20 @@
  */
 import { Context, Effect, Layer } from "effect"
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from "testcontainers"
-import type { ComposeExecutableOptions } from "testcontainers/build/container-runtime"
+
+/**
+ * @since 0.0.1
+ * @category models
+ */
+export type ComposeExecutableOptions = {
+  executablePath: string
+  options?: string[] | (string | string[])[]
+  standalone?: never
+} | {
+  executablePath?: string
+  options?: never
+  standalone: true
+}
 
 /**
  * @since 0.0.1

--- a/packages/testcontainers/src/ComposeContainer.ts
+++ b/packages/testcontainers/src/ComposeContainer.ts
@@ -10,7 +10,7 @@ import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from "
  */
 export type ComposeExecutableOptions = {
   executablePath: string
-  options?: string[] | (string | string[])[]
+  options?: Array<string> | Array<string | Array<string>>
   standalone?: never
 } | {
   executablePath?: string

--- a/packages/vitest-neo4j/package.json
+++ b/packages/vitest-neo4j/package.json
@@ -43,6 +43,6 @@
     "@evryg/effect-neo4j": "workspace:^",
     "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
-    "vitest": "^3.2.1"
+    "vitest": "^2.1.9"
   }
 }

--- a/packages/vitest-neo4j/package.json
+++ b/packages/vitest-neo4j/package.json
@@ -37,14 +37,12 @@
     "@evryg/effect-neo4j": "workspace:^",
     "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
-    "neo4j-driver-core": "^6.0.1",
     "vitest": "^2.1.9"
   },
   "devDependencies": {
     "@evryg/effect-neo4j": "workspace:^",
     "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
-    "neo4j-driver-core": "^6.0.1",
     "vitest": "^3.2.1"
   }
 }

--- a/packages/vitest-neo4j/package.json
+++ b/packages/vitest-neo4j/package.json
@@ -37,7 +37,8 @@
     "@evryg/effect-neo4j": "workspace:^",
     "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
-    "neo4j-driver-core": "^6.0.1"
+    "neo4j-driver-core": "^6.0.1",
+    "vitest": "^2.1.9"
   },
   "devDependencies": {
     "@evryg/effect-neo4j": "workspace:^",

--- a/packages/vitest-neo4j/package.json
+++ b/packages/vitest-neo4j/package.json
@@ -34,14 +34,14 @@
     "coverage": "vitest --coverage"
   },
   "peerDependencies": {
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-testcontainers-neo4j": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "neo4j-driver-core": "^6.0.1"
   },
   "devDependencies": {
-    "@evryg/effect-neo4j": "workspace:*",
-    "@evryg/effect-testcontainers-neo4j": "workspace:*",
+    "@evryg/effect-neo4j": "workspace:^",
+    "@evryg/effect-testcontainers-neo4j": "workspace:^",
     "effect": "^3.21.0",
     "neo4j-driver-core": "^6.0.1",
     "vitest": "^3.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,8 +83,8 @@ importers:
         specifier: ^0.1.0
         version: 0.1.0
       '@effect/vitest':
-        specifier: ^0.12.1
-        version: 0.12.1(effect@3.21.0)(vitest@2.1.9)
+        specifier: ^0.29.0
+        version: 0.29.0(effect@3.21.0)(vitest@2.1.9)
       '@eslint/compat':
         specifier: 1.1.1
         version: 1.1.1
@@ -1282,12 +1282,6 @@ packages:
     resolution: {integrity: sha512-L/2o2ImeqbemFlqH0b3y2PqQTFc+E0/DUnffCU8bkJUGh0yUZmh2RXuXhR8QOpfNCe718JQjI+mLnpVF2MMmaQ==}
     peerDependencies:
       effect: ^3.21.0
-
-  '@effect/vitest@0.12.1':
-    resolution: {integrity: sha512-dUzg1CVgro8aeAVYeCEEMQlnx60CXxbztxH9KDG6/oLRZ/YixHWNytA9PGsC9UPYSgHAahjsn446HgQAnCpX4Q==}
-    peerDependencies:
-      effect: ^3.9.2
-      vitest: ^2.1.9
 
   '@effect/vitest@0.29.0':
     resolution: {integrity: sha512-DvWr1aeEcaZ8mtu8hNVb4e3rEYvGEwQSr7wsNrW53t6nKYjkmjRICcvVEsXUhjoCblRHSxRsRV0TOt0+UmcvaQ==}
@@ -6552,15 +6546,10 @@ snapshots:
     dependencies:
       effect: 3.21.0
 
-  '@effect/vitest@0.12.1(effect@3.21.0)(vitest@2.1.9)':
-    dependencies:
-      effect: 3.21.0
-      vitest: 2.1.9(@edge-runtime/vm@4.0.1)(@types/node@24.12.2)(@vitest/browser@2.1.9)(msw@2.12.10(@types/node@24.12.2)(typescript@5.6.2))(terser@5.32.0)
-
   '@effect/vitest@0.29.0(effect@3.21.0)(vitest@2.1.9)':
     dependencies:
       effect: 3.21.0
-      vitest: 2.1.9(@edge-runtime/vm@4.0.3)(@types/node@24.12.2)(@vitest/browser@2.1.9)(msw@2.12.10(@types/node@24.12.2)(typescript@5.6.2))(terser@5.32.0)
+      vitest: 2.1.9(@edge-runtime/vm@4.0.1)(@types/node@24.12.2)(@vitest/browser@2.1.9)(msw@2.12.10(@types/node@24.12.2)(typescript@5.6.2))(terser@5.32.0)
 
   '@effect/workflow@0.18.0(@effect/experimental@0.60.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(@effect/platform@0.96.0(effect@3.21.0))(@effect/rpc@0.75.0(@effect/platform@0.96.0(effect@3.21.0))(effect@3.21.0))(effect@3.21.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,10 +182,10 @@ importers:
   packages/cypher-codegen:
     dependencies:
       '@evryg/effect-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../neo4j
       '@evryg/effect-neo4j-schema':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../neo4j-schema
       antlr4ng:
         specifier: ^3.0.16
@@ -204,7 +204,7 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.0)(vitest@2.1.9)
       '@evryg/effect-vitest-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../vitest-neo4j
       antlr-ng:
         specifier: ^1.0.10
@@ -261,10 +261,10 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.0)(vitest@2.1.9)
       '@evryg/effect-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../neo4j
       '@evryg/effect-vitest-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../vitest-neo4j
       effect:
         specifier: ^3.21.0
@@ -296,10 +296,10 @@ importers:
         specifier: ^0.29.0
         version: 0.29.0(effect@3.21.0)(vitest@2.1.9)
       '@evryg/effect-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../neo4j
       '@evryg/effect-testcontainers':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../testcontainers
       '@testcontainers/neo4j':
         specifier: ^11.12.0
@@ -315,10 +315,10 @@ importers:
   packages/vitest-neo4j:
     devDependencies:
       '@evryg/effect-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../neo4j
       '@evryg/effect-testcontainers-neo4j':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../testcontainers-neo4j
       effect:
         specifier: ^3.21.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -323,9 +323,6 @@ importers:
       effect:
         specifier: ^3.21.0
         version: 3.21.0
-      neo4j-driver-core:
-        specifier: ^6.0.1
-        version: 6.0.1
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@edge-runtime/vm@4.0.3)(@types/node@24.12.2)(@vitest/browser@2.1.9)(msw@2.12.10(@types/node@24.12.2)(typescript@5.6.2))(terser@5.32.0)


### PR DESCRIPTION
## Summary

- Use `workspace:^` instead of `workspace:*` for internal cross-package references — `workspace:*` publishes as `*` (any version) while `workspace:^` publishes as `^<current-version>`
- Add missing `vitest` peer dependency to `@evryg/effect-vitest-neo4j` — source imports from `vitest` at runtime, matching the pattern used by `@effect/vitest`
- Remove unused `neo4j-driver-core` peer dependency from `@evryg/effect-vitest-neo4j` — never imported in source
- Align vitest devDependencies to `^2.1.9` across all packages to match the root pnpm override
- Update root `@effect/vitest` from `^0.12.1` to `^0.29.0` to match packages
- Inline `ComposeExecutableOptions` type in `@evryg/effect-testcontainers` to remove fragile import from `testcontainers/build/container-runtime` (internal, unexported path)
- Apply linter formatting to inlined `ComposeExecutableOptions` type

## Affected packages

`@evryg/effect-cypher-codegen`, `@evryg/effect-neo4j-schema`, `@evryg/effect-testcontainers`, `@evryg/effect-testcontainers-neo4j`, `@evryg/effect-vitest-neo4j`

## Test plan

- [ ] `pnpm install` resolves cleanly
- [ ] `pnpm build` compiles without errors
- [ ] `pnpm test` passes