### PR TITLE
Set up Effect tooling, replace global errors with tagged errors

### DIFF
--- a/.changeset/effect-solutions-errors.md
+++ b/.changeset/effect-solutions-errors.md
@@ -1,0 +1,9 @@
+---
+"@evryg/effect-cypher-codegen": patch
+"@evryg/effect-testcontainers": patch
+---
+
+Replace global Error with tagged errors and export them as top-level API
+
+- cypher-codegen: Add `CypherCodegenError` and `DuplicateCypherFilenamesError` tagged errors, combine multiple `Effect.provide` calls into single array provide
+- testcontainers: Add `ComposeContainerError` and `TestContainerError` tagged errors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+<!-- effect-solutions:start -->
+## Effect Best Practices
+
+**IMPORTANT:** Always consult effect-solutions before writing Effect code.
+
+1. Run `effect-solutions list` to see available guides
+2. Run `effect-solutions show <topic>...` for relevant patterns (supports multiple topics)
+3. Search `~/.local/share/effect-solutions/effect` for real implementations
+
+Topics: quick-start, project-setup, tsconfig, basics, services-and-layers, data-modeling, error-handling, config, testing, cli.
+
+Never guess at Effect patterns - check the guide first.
+<!-- effect-solutions:end -->

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "pnpm dlx @effect/language-service patch",
     "clean": "node scripts/clean.mjs",
     "codegen": "pnpm --recursive --parallel run codegen",
     "codemod": "node scripts/codemod.mjs",

--- a/packages/cypher-codegen/src/index.ts
+++ b/packages/cypher-codegen/src/index.ts
@@ -37,15 +37,15 @@ export {
 } from "./frontend/InferType.js"
 
 /**
- * @since 0.1.0
+ * @since 0.1.1
  */
 export {
   /**
-   * @since 0.1.0
+   * @since 0.1.1
    */
   CypherCodegenError,
   /**
-   * @since 0.1.0
+   * @since 0.1.1
    */
   DuplicateCypherFilenamesError
 } from "./internal/cli/commands/Shared.js"

--- a/packages/cypher-codegen/src/index.ts
+++ b/packages/cypher-codegen/src/index.ts
@@ -37,6 +37,20 @@ export {
 } from "./frontend/InferType.js"
 
 /**
+ * @since 0.1.0
+ */
+export {
+  /**
+   * @since 0.1.0
+   */
+  CypherCodegenError,
+  /**
+   * @since 0.1.0
+   */
+  DuplicateCypherFilenamesError
+} from "./internal/cli/commands/Shared.js"
+
+/**
  * @since 0.0.1
  */
 export {

--- a/packages/cypher-codegen/src/internal/cli/commands/ExtractSchema.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/ExtractSchema.ts
@@ -20,5 +20,5 @@ export const extractSchemaCommand = Command.make(
       yield* Console.log(
         `  ${schema.vertexProperties.length} vertex properties, ${schema.edgeProperties.length} edge properties`
       )
-    }).pipe(Effect.provide(neo4jLayer(opts)), Effect.provide(NodeContext.layer))
+    }).pipe(Effect.provide([neo4jLayer(opts), NodeContext.layer]))
 )

--- a/packages/cypher-codegen/src/internal/cli/commands/Generate.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/Generate.ts
@@ -24,7 +24,7 @@ const generateLiveDbCommand = Command.make(
       yield* saveSchema(opts.schemaPath, schema)
       yield* Console.log(`Schema extracted: ${schema.vertexProperties.length} vertex properties`)
       yield* generateFromSchema(schema, opts.output, opts.cypherGlob)
-    }).pipe(Effect.provide(neo4jLayer(opts)), Effect.provide(NodeContext.layer))
+    }).pipe(Effect.provide([neo4jLayer(opts), NodeContext.layer]))
 )
 
 // ── generate annotations ──

--- a/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
@@ -2,7 +2,7 @@
 import { Options } from "@effect/cli"
 import { Neo4jConfig, UnconfiguredNeo4jClient } from "@evryg/effect-neo4j"
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
-import { Console, Effect, Either, Layer } from "effect"
+import { Console, Effect, Either, Layer, Schema } from "effect"
 import { globSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
 import { basename, dirname } from "node:path"
 import { type BarrelEntry, extractParams, generateBarrel } from "../../../backend/CypherCodegen.js"
@@ -87,6 +87,40 @@ export function neo4jLayer(
   )
 }
 
+// ── Errors ──
+
+/**
+ * @since 0.1.0
+ * @category errors
+ */
+export class DuplicateCypherFilenamesError extends Schema.TaggedError<DuplicateCypherFilenamesError>(
+  "@evryg/effect-cypher-codegen/DuplicateCypherFilenamesError"
+)("DuplicateCypherFilenamesError", {
+  filenames: Schema.Array(Schema.String)
+}) {
+  override get message() {
+    return `Duplicate .cypher filenames: ${this.filenames.join(", ")}`
+  }
+}
+
+/**
+ * @since 0.1.0
+ * @category errors
+ */
+export class CypherCodegenError extends Schema.TaggedError<CypherCodegenError>(
+  "@evryg/effect-cypher-codegen/CypherCodegenError"
+)("CypherCodegenError", {
+  failures: Schema.Array(Schema.Struct({
+    filename: Schema.String,
+    error: Schema.String
+  }))
+}) {
+  override get message() {
+    const details = this.failures.map((f) => `  ✗ ${f.filename}: ${f.error}`).join("\n")
+    return `${this.failures.length} Cypher type error(s):\n${details}`
+  }
+}
+
 // ── Shared codegen logic ──
 
 function mergeParams(analyzerParams: ReadonlyArray<ResolvedParam>, cypher: string): Array<ResolvedParam> {
@@ -102,14 +136,18 @@ function mergeParams(analyzerParams: ReadonlyArray<ResolvedParam>, cypher: strin
  * @since 0.0.1
  * @category codegen
  */
-export function generateFromSchema(schema: GraphSchema, output: string, cypherGlob: string) {
+export function generateFromSchema(
+  schema: GraphSchema,
+  output: string,
+  cypherGlob: string
+) {
   return Effect.gen(function*() {
     const files = globSync(cypherGlob).filter((f) => !basename(f).endsWith("GraphSchema.cypher"))
 
     const filenames = files.map((f) => basename(f))
     const duplicates = filenames.filter((name, i) => filenames.indexOf(name) !== i)
     if (duplicates.length > 0) {
-      return yield* Effect.fail(new Error(`Duplicate .cypher filenames: ${[...new Set(duplicates)].join(", ")}`))
+      return yield* new DuplicateCypherFilenamesError({ filenames: [...new Set(duplicates)] })
     }
 
     const eithers = files.map((file) =>
@@ -137,12 +175,7 @@ export function generateFromSchema(schema: GraphSchema, output: string, cypherGl
       })
     }
 
-    if (failures.length > 0) {
-      for (const f of failures) {
-        yield* Console.error(`✗ ${f.filename}: ${f.error}`)
-      }
-      return yield* Effect.fail(new Error(`${failures.length} Cypher type error(s)`))
-    }
+    if (failures.length > 0) return yield* new CypherCodegenError({ failures })
 
     const content = generateBarrel(entries)
     mkdirSync(dirname(output), { recursive: true })

--- a/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
@@ -90,7 +90,7 @@ export function neo4jLayer(
 // ── Errors ──
 
 /**
- * @since 0.1.0
+ * @since 0.1.1
  * @category errors
  */
 export class DuplicateCypherFilenamesError extends Schema.TaggedError<DuplicateCypherFilenamesError>(
@@ -104,7 +104,7 @@ export class DuplicateCypherFilenamesError extends Schema.TaggedError<DuplicateC
 }
 
 /**
- * @since 0.1.0
+ * @since 0.1.1
  * @category errors
  */
 export class CypherCodegenError extends Schema.TaggedError<CypherCodegenError>(

--- a/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
@@ -109,7 +109,7 @@ export function generateFromSchema(schema: GraphSchema, output: string, cypherGl
     const filenames = files.map((f) => basename(f))
     const duplicates = filenames.filter((name, i) => filenames.indexOf(name) !== i)
     if (duplicates.length > 0) {
-      yield* Effect.fail(new Error(`Duplicate .cypher filenames: ${[...new Set(duplicates)].join(", ")}`))
+      return yield* Effect.fail(new Error(`Duplicate .cypher filenames: ${[...new Set(duplicates)].join(", ")}`))
     }
 
     const eithers = files.map((file) =>
@@ -141,7 +141,7 @@ export function generateFromSchema(schema: GraphSchema, output: string, cypherGl
       for (const f of failures) {
         yield* Console.error(`✗ ${f.filename}: ${f.error}`)
       }
-      yield* Effect.fail(new Error(`${failures.length} Cypher type error(s)`))
+      return yield* Effect.fail(new Error(`${failures.length} Cypher type error(s)`))
     }
 
     const content = generateBarrel(entries)

--- a/packages/testcontainers/src/ComposeContainer.ts
+++ b/packages/testcontainers/src/ComposeContainer.ts
@@ -1,8 +1,16 @@
 /**
  * @since 0.0.1
  */
-import { Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer, Schema } from "effect"
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from "testcontainers"
+
+/**
+ * @since 0.1.0
+ * @category errors
+ */
+export class ComposeContainerError extends Schema.TaggedError<ComposeContainerError>()("ComposeContainerError", {
+  cause: Schema.Defect
+}) {}
 
 /**
  * @since 0.0.1
@@ -44,7 +52,7 @@ export interface ComposeOptions {
  */
 export const makeComposeContainer = (
   opts: ComposeOptions
-): Layer.Layer<ComposeEnvironment, Error> =>
+): Layer.Layer<ComposeEnvironment, ComposeContainerError> =>
   Layer.scoped(
     ComposeEnvironment,
     Effect.gen(function*() {
@@ -52,7 +60,7 @@ export const makeComposeContainer = (
       if (opts.executable) env = env.withClientOptions({ executable: opts.executable })
       if (opts.waitStrategy) env = opts.waitStrategy(env)
       const started = yield* Effect.acquireRelease(
-        Effect.tryPromise({ try: () => env.up(), catch: (e) => new Error(String(e)) }),
+        Effect.tryPromise({ try: () => env.up(), catch: (cause) => new ComposeContainerError({ cause }) }),
         (c) => Effect.promise(() => c.down()).pipe(Effect.orDie)
       )
       yield* Effect.log("[testcontainers] Compose started")

--- a/packages/testcontainers/src/ComposeContainer.ts
+++ b/packages/testcontainers/src/ComposeContainer.ts
@@ -5,7 +5,7 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { DockerComposeEnvironment, type StartedDockerComposeEnvironment } from "testcontainers"
 
 /**
- * @since 0.1.0
+ * @since 0.0.3
  * @category errors
  */
 export class ComposeContainerError extends Schema.TaggedError<ComposeContainerError>()("ComposeContainerError", {

--- a/packages/testcontainers/src/TestContainer.ts
+++ b/packages/testcontainers/src/TestContainer.ts
@@ -6,7 +6,7 @@ import { Effect, Schema } from "effect"
 import type { StartedTestContainer } from "testcontainers"
 
 /**
- * @since 0.1.0
+ * @since 0.0.3
  * @category errors
  */
 export class TestContainerError extends Schema.TaggedError<TestContainerError>()("TestContainerError", {

--- a/packages/testcontainers/src/TestContainer.ts
+++ b/packages/testcontainers/src/TestContainer.ts
@@ -2,8 +2,16 @@
  * @since 0.0.1
  */
 import type { Scope } from "effect"
-import { Effect } from "effect"
+import { Effect, Schema } from "effect"
 import type { StartedTestContainer } from "testcontainers"
+
+/**
+ * @since 0.1.0
+ * @category errors
+ */
+export class TestContainerError extends Schema.TaggedError<TestContainerError>()("TestContainerError", {
+  cause: Schema.Defect
+}) {}
 
 /**
  * @since 0.0.1
@@ -11,8 +19,8 @@ import type { StartedTestContainer } from "testcontainers"
  */
 export const acquireContainer = <C extends StartedTestContainer>(
   start: () => Promise<C>
-): Effect.Effect<C, Error, Scope.Scope> =>
+): Effect.Effect<C, TestContainerError, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.tryPromise({ try: start, catch: (e) => new Error(String(e)) }),
+    Effect.tryPromise({ try: start, catch: (cause) => new TestContainerError({ cause }) }),
     (c) => Effect.promise(() => c.stop()).pipe(Effect.orDie)
   )

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -3,10 +3,7 @@
  */
 export {
   /**
-   * @since 0.0.1
-   */
-  /**
-   * @since 0.1.0
+   * @since 0.0.3
    */
   ComposeContainerError,
   /**
@@ -32,7 +29,7 @@ export {
    */
   acquireContainer,
   /**
-   * @since 0.1.0
+   * @since 0.0.3
    */
   TestContainerError
 } from "./TestContainer.js"

--- a/packages/testcontainers/src/index.ts
+++ b/packages/testcontainers/src/index.ts
@@ -5,6 +5,13 @@ export {
   /**
    * @since 0.0.1
    */
+  /**
+   * @since 0.1.0
+   */
+  ComposeContainerError,
+  /**
+   * @since 0.0.1
+   */
   ComposeEnvironment,
   /**
    * @since 0.0.1
@@ -23,5 +30,9 @@ export {
   /**
    * @since 0.0.1
    */
-  acquireContainer
+  acquireContainer,
+  /**
+   * @since 0.1.0
+   */
+  TestContainerError
 } from "./TestContainer.js"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/language-service/refs/heads/main/schema.json",
   "compilerOptions": {
     "strict": true,
     "exactOptionalPropertyTypes": true,
@@ -6,6 +7,8 @@
     "composite": true,
     "downlevelIteration": true,
     "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "rewriteRelativeImportExtensions": true,
     "esModuleInterop": false,
     "declaration": true,
     "skipLibCheck": true,
@@ -21,6 +24,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
     "noEmitOnError": false,
     "noErrorTruncation": false,
     "allowJs": false,


### PR DESCRIPTION
## Summary

- Set up Effect project tooling (`effect-solutions`) and fix Language Service diagnostics
- Configure `tsconfig.base.json` with `exactOptionalPropertyTypes` and `noUncheckedIndexedAccess`
- Combine multiple `Effect.provide` calls into single array provide in cypher-codegen CLI commands
- Replace global `Error` with tagged errors across packages:
  - `@evryg/effect-cypher-codegen`: add `CypherCodegenError` and `DuplicateCypherFilenamesError`
  - `@evryg/effect-testcontainers`: add `ComposeContainerError` and `TestContainerError`
- Export new error classes as top-level API from both packages
- Fix `@since` annotations to match upcoming release versions

## Test plan

- [ ] Verify `pnpm check` passes with no diagnostics
- [ ] Verify cypher-codegen CLI commands surface tagged errors correctly
- [ ] Verify testcontainers error types are accessible from package imports