### PR TITLE
Promote cypher-codegen integration modules to top-level exports

### DIFF
--- a/.changeset/promote-integration-exports.md
+++ b/.changeset/promote-integration-exports.md
@@ -1,0 +1,9 @@
+---
+"@evryg/effect-cypher-codegen": minor
+---
+
+Promote integration modules to top-level exports following Effect ecosystem conventions.
+
+- `./integration/codegen` → `./Codegen`
+- `./integration/Register` → `./Register`
+- `./integration/VitePlugin` → `./VitePlugin`

--- a/packages/cypher-codegen/package.json
+++ b/packages/cypher-codegen/package.json
@@ -15,9 +15,9 @@
   },
   "exports": {
     ".": "./src/index.ts",
-    "./integration/VitePlugin": "./src/integration/VitePlugin.ts",
-    "./integration/Register": "./src/integration/Register.ts",
-    "./integration/codegen": "./src/integration/codegen.ts",
+    "./Codegen": "./src/Codegen.ts",
+    "./Register": "./src/Register.ts",
+    "./VitePlugin": "./src/VitePlugin.ts",
     "./internal/*": null
   },
   "publishConfig": {

--- a/packages/cypher-codegen/src/Codegen.ts
+++ b/packages/cypher-codegen/src/Codegen.ts
@@ -3,9 +3,9 @@ import { Command } from "@effect/cli"
 import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 import type { Schema } from "effect"
-import { makeApplySchemaCommand } from "../internal/cli/commands/ApplySchema.js"
-import { extractSchemaCommand } from "../internal/cli/commands/ExtractSchema.js"
-import { makeGenerateCommand } from "../internal/cli/commands/Generate.js"
+import { makeApplySchemaCommand } from "./internal/cli/commands/ApplySchema.js"
+import { extractSchemaCommand } from "./internal/cli/commands/ExtractSchema.js"
+import { makeGenerateCommand } from "./internal/cli/commands/Generate.js"
 
 /**
  * @since 0.0.1

--- a/packages/cypher-codegen/src/Register.ts
+++ b/packages/cypher-codegen/src/Register.ts
@@ -5,8 +5,8 @@ import { Effect } from "effect"
 import { readFileSync } from "node:fs"
 import { registerHooks } from "node:module"
 import { fileURLToPath } from "node:url"
-import { generateModule } from "../backend/CypherCodegen.js"
-import { analyzeQuery } from "../frontend/QueryAnalyzer.js"
+import { generateModule } from "./backend/CypherCodegen.js"
+import { analyzeQuery } from "./frontend/QueryAnalyzer.js"
 
 let schema: GraphSchema | undefined
 try {

--- a/packages/cypher-codegen/src/VitePlugin.ts
+++ b/packages/cypher-codegen/src/VitePlugin.ts
@@ -1,8 +1,8 @@
 /** @since 0.0.1 */
 import type { GraphSchema } from "@evryg/effect-neo4j-schema"
 import { readFileSync } from "node:fs"
-import { generateModule } from "../backend/CypherCodegen.js"
-import { analyzeQuery } from "../frontend/QueryAnalyzer.js"
+import { generateModule } from "./backend/CypherCodegen.js"
+import { analyzeQuery } from "./frontend/QueryAnalyzer.js"
 
 /**
  * @since 0.0.1

--- a/packages/cypher-codegen/src/index.ts
+++ b/packages/cypher-codegen/src/index.ts
@@ -70,7 +70,7 @@ export {
    * @since 0.0.1
    */
   cypherPlugin
-} from "./integration/VitePlugin.js"
+} from "./VitePlugin.js"
 
 /**
  * @since 0.0.1

--- a/packages/cypher-codegen/vitest.config.ts
+++ b/packages/cypher-codegen/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, mergeConfig } from "vitest/config"
 import shared from "../../vitest.shared"
-import { cypherPlugin } from "./src/integration/VitePlugin.ts"
+import { cypherPlugin } from "./src/VitePlugin.ts"
 
 export default mergeConfig(shared, defineConfig({
   plugins: [cypherPlugin()],


### PR DESCRIPTION
## Summary

- Move `Register.ts`, `VitePlugin.ts`, and `codegen.ts` from `src/integration/` to `src/` (renamed to `Codegen.ts`)
- Update source `exports` field to flat top-level paths: `./Codegen`, `./Register`, `./VitePlugin`
- Fix all internal import paths (`../backend/` → `./backend/`, etc.)
- No custom `effect.generateExports` config needed — the default `pack-v2` glob (`["*.ts"]`) now discovers them automatically

Follows the Effect ecosystem convention where all public modules are flat top-level exports (e.g. `@effect/platform/HttpClient`, not `@effect/platform/adapters/HttpClient`).

## Test plan

- [x] `pnpm build` succeeds and `dist/package.json` exports map contains `./Codegen`, `./Register`, `./VitePlugin`
- [ ] `pnpm test` passes
- [ ] Consumers update imports: `@evryg/effect-cypher-codegen/Codegen` instead of `@evryg/effect-cypher-codegen/integration/codegen`

🤖 Generated with [Claude Code](https://claude.com/claude-code)