### PR TITLE
Remove neo4j-driver peer dependency from effect-integresql

### DIFF
--- a/packages/integresql/package.json
+++ b/packages/integresql/package.json
@@ -37,8 +37,7 @@
     "fast-glob": "^3.3.2"
   },
   "peerDependencies": {
-    "effect": "^3.21.0",
-    "neo4j-driver": "^6.0.1"
+    "effect": "^3.21.0"
   },
   "devDependencies": {
     "effect": "^3.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,9 +193,6 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
-      neo4j-driver:
-        specifier: ^6.0.1
-        version: 6.0.1
     devDependencies:
       '@effect/platform':
         specifier: ^0.94.4


### PR DESCRIPTION
## Summary
- Remove incorrect `neo4j-driver` peer dependency from `@evryg/effect-integresql` (copy-paste artifact from neo4j packages)

## Test plan
- [x] Package builds successfully
- [x] Publish dry-run passes