### PR TITLE
Remove test sharding from CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,27 +39,12 @@ jobs:
       - run: pnpm lint
 
   test:
-    name: Test (${{ matrix.runtime }} ${{ matrix.shard }})
+    name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1/4, 2/4, 3/4, 4/4]
-        # runtime: [Node, Bun] # TODO: Re-enable bun test suite after https://github.com/oven-sh/bun/issues/4145 is resolved
-        runtime: [Node]
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
         uses: ./.github/actions/setup
       - run: pnpm codegen
-      - uses: oven-sh/setup-bun@v1
-        if: matrix.runtime == 'Bun'
-        with:
-          bun-version: 1.0.25
-      - name: Test
-        run: pnpm vitest --shard ${{ matrix.shard }}
-        if: matrix.runtime == 'Node'
-      - name: Test
-        run: bun vitest --shard ${{ matrix.shard }}
-        if: matrix.runtime == 'Bun'
+      - run: pnpm vitest


### PR DESCRIPTION
## Summary
- Remove 4-shard test matrix — only ~9 unit test files exist, so shard 4/4 ends up empty and fails with "No test files found"
- Simplifies CI to a single test job running `pnpm vitest`

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)