### PR TITLE
cypher-codegen: type CREATE/MERGE returns, nullable params, and param atoms

### DIFF
--- a/.changeset/cypher-create-merge-params.md
+++ b/.changeset/cypher-create-merge-params.md
@@ -1,0 +1,9 @@
+---
+"@evryg/effect-cypher-codegen": minor
+---
+
+Support type inference for `CREATE`/`MERGE` mutations and nullable parameters
+
+- Bind `CREATE`/`MERGE` pattern variables into the type environment, so a `RETURN` referencing a created or merged node (e.g. `CREATE (n:Node {...}) RETURN n.id AS id`) resolves its column types from the schema instead of throwing `Unbound variable`. Created/merged nodes are non-nullable.
+- Emit `T | null` for parameters bound to optional vertex properties, matching the `NullOr` treatment those properties already get on the `RETURN` side (so callers can pass `null` to clear a property). `IN`-clause params stay non-nullable.
+- Infer bare parameter atoms in projections (`RETURN $id AS id`) as a `String` scalar instead of throwing `Unhandled atom expression`.

--- a/packages/cypher-codegen/src/backend/CypherCodegen.node.unit.test.ts
+++ b/packages/cypher-codegen/src/backend/CypherCodegen.node.unit.test.ts
@@ -236,6 +236,17 @@ describe("generateBarrel — typed params", () => {
     expect(source).toContain("{ val }: { val: unknown }")
   })
 
+  it("appends | null for a nullable param", () => {
+    const entry: BarrelEntry = {
+      filename: "Note.cypher",
+      cypher: "MERGE (m:Method {id: $id}) SET m.note = $note RETURN m.id AS id",
+      columns: [col("id", S("String"), false)],
+      params: [{ name: "note", type: "String", nullable: true } as ResolvedParam]
+    }
+    const source = generateBarrel([entry])
+    expect(source).toContain("{ note }: { note: string | null }")
+  })
+
   it("emits shared Neo4jRecordToObject transform once", () => {
     const entry: BarrelEntry = {
       filename: "Foo.cypher",

--- a/packages/cypher-codegen/src/backend/CypherCodegen.ts
+++ b/packages/cypher-codegen/src/backend/CypherCodegen.ts
@@ -346,7 +346,8 @@ export function generateBarrel(entries: ReadonlyArray<BarrelEntry>): string {
         lines.push(`    Effect.map(neo4j.query(${name}Cypher), ${decodeName}))`)
       } else {
         const destructure = `{ ${entry.params.map((p) => p.name).join(", ")} }`
-        const typeAnnotation = entry.params.map((p) => `${p.name}: ${tsTypeFor(p.type)}`).join("; ")
+        const typeAnnotation = entry.params.map((p) => `${p.name}: ${tsTypeFor(p.type)}${p.nullable ? " | null" : ""}`)
+          .join("; ")
         lines.push(`export const ${name} = (${destructure}: { ${typeAnnotation} }) =>`)
         lines.push(`  Effect.flatMap(Neo4jClient, (neo4j) =>`)
         lines.push(`    Effect.map(neo4j.query(${name}Cypher, ${destructure}), ${decodeName}))`)
@@ -357,7 +358,8 @@ export function generateBarrel(entries: ReadonlyArray<BarrelEntry>): string {
         lines.push(`  Effect.flatMap(Neo4jClient, (neo4j) => neo4j.query(${name}Cypher))`)
       } else {
         const destructure = `{ ${entry.params.map((p) => p.name).join(", ")} }`
-        const typeAnnotation = entry.params.map((p) => `${p.name}: ${tsTypeFor(p.type)}`).join("; ")
+        const typeAnnotation = entry.params.map((p) => `${p.name}: ${tsTypeFor(p.type)}${p.nullable ? " | null" : ""}`)
+          .join("; ")
         lines.push(`export const ${name} = (${destructure}: { ${typeAnnotation} }) =>`)
         lines.push(`  Effect.flatMap(Neo4jClient, (neo4j) => neo4j.query(${name}Cypher, ${destructure}))`)
       }

--- a/packages/cypher-codegen/src/backend/CypherDeclarationGen.node.unit.test.ts
+++ b/packages/cypher-codegen/src/backend/CypherDeclarationGen.node.unit.test.ts
@@ -102,6 +102,15 @@ describe("generateDeclarations", () => {
     expect(output).toContain("fqcn: string")
   })
 
+  it("appends | null for a nullable param", () => {
+    const output = generateDeclarations([
+      entry("Foo.cypher", [col("name", S("String"), false)], [
+        { name: "note", type: "String", nullable: true } as ResolvedParam
+      ])
+    ])
+    expect(output).toContain("note: string | null")
+  })
+
   it("generates parameterless function when no params", () => {
     const output = generateDeclarations([
       entry("Foo.cypher", [col("id", S("String"), false)])

--- a/packages/cypher-codegen/src/backend/CypherDeclarationGen.ts
+++ b/packages/cypher-codegen/src/backend/CypherDeclarationGen.ts
@@ -103,7 +103,8 @@ export const generateDeclaration = (entry: QueryEntry): string => {
   if (entry.params.length === 0) {
     lines.push(`export declare const query: () => Effect.Effect<Row[], Neo4jQueryError, Neo4jClient>`)
   } else {
-    const paramFields = entry.params.map((p) => `${p.name}: ${tsTypeForParam(p.type)}`).join(", ")
+    const paramFields = entry.params.map((p) => `${p.name}: ${tsTypeForParam(p.type)}${p.nullable ? " | null" : ""}`)
+      .join(", ")
     lines.push(
       `export declare const query: (params: { ${paramFields} }) => Effect.Effect<Row[], Neo4jQueryError, Neo4jClient>`
     )
@@ -137,7 +138,8 @@ export const generateDeclarations = (queries: ReadonlyArray<QueryEntry>): string
     if (entry.params.length === 0) {
       lines.push(`  export const query: () => Effect.Effect<Row[], Neo4jQueryError, Neo4jClient>`)
     } else {
-      const paramFields = entry.params.map((p) => `${p.name}: ${tsTypeForParam(p.type)}`).join(", ")
+      const paramFields = entry.params.map((p) => `${p.name}: ${tsTypeForParam(p.type)}${p.nullable ? " | null" : ""}`)
+        .join(", ")
       lines.push(
         `  export const query: (params: { ${paramFields} }) => Effect.Effect<Row[], Neo4jQueryError, Neo4jClient>`
       )

--- a/packages/cypher-codegen/src/frontend/InferType.node.unit.test.ts
+++ b/packages/cypher-codegen/src/frontend/InferType.node.unit.test.ts
@@ -101,6 +101,13 @@ describe("inferExpressionType — variable lookup", () => {
   })
 })
 
+describe("inferExpressionType — parameter atoms", () => {
+  it("infers a bare parameter as a scalar instead of throwing", () => {
+    const result = inferExpressionType(parseExpression("$id"), emptyEnv, schema)
+    expect(result).toEqual(new ScalarType({ scalarType: "String" }))
+  })
+})
+
 describe("inferExpressionType — property access", () => {
   it("resolves node property from schema", () => {
     const env = envWith({ c: { type: new VertexType({ label: "Class" }), nullable: false } })

--- a/packages/cypher-codegen/src/frontend/InferType.ts
+++ b/packages/cypher-codegen/src/frontend/InferType.ts
@@ -482,6 +482,12 @@ function inferAtomType(
     throw new CypherTypeError(`Unbound variable '${name}'`)
   }
 
+  // Parameter atom ($id): the param's value type isn't threaded into expression
+  // inference, so fall back to a String scalar rather than failing the projection.
+  if (atom.parameter()) {
+    return new ScalarType({ scalarType: "String" })
+  }
+
   throw new CypherTypeError("Unhandled atom expression")
 }
 

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
@@ -730,3 +730,40 @@ describe("analyzeQuery — edge connectivity inference", () => {
     expect(result.columns[0]).toEqual(col("name", S("String"), false))
   })
 })
+
+describe("analyzeQuery — CREATE/MERGE-bound variables in RETURN", () => {
+  it("resolves a property of a CREATE-bound variable from the schema", () => {
+    const cypher = "CREATE (m:Method {id: $id, name: $name}) RETURN m.id AS id, m.name AS name"
+    const result = analyzeQuery(cypher, schema)
+    // Method.id and Method.name are mandatory String → non-nullable, resolved from schema
+    expect(result.columns).toEqual([
+      col("id", S("String"), false),
+      col("name", S("String"), false)
+    ])
+  })
+
+  it("makes an optional property of a CREATE-bound variable nullable", () => {
+    const cypher = "CREATE (m:Method {id: $id}) RETURN m.visibility AS visibility"
+    const result = analyzeQuery(cypher, schema)
+    // Method.visibility is optional → nullable, but the created node itself is never null
+    expect(result.columns).toEqual([col("visibility", S("String"), true)])
+  })
+
+  it("resolves a property of a MERGE-bound variable from the schema", () => {
+    const cypher = "MERGE (m:Method {id: $id}) RETURN m.name AS name"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.columns).toEqual([col("name", S("String"), false)])
+  })
+
+  it("resolves CREATE-bound variables introduced after a WITH in a multi-part query", () => {
+    const cypher = `MATCH (c:Class)
+                    WITH c
+                    CREATE (m:Method {id: $id})
+                    RETURN m.id AS id, c.fqcn AS fqcn`
+    const result = analyzeQuery(cypher, schema)
+    expect(result.columns).toEqual([
+      col("id", S("String"), false),
+      col("fqcn", S("String"), false)
+    ])
+  })
+})

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
@@ -78,7 +78,8 @@ const S = (t: "String" | "Long" | "Double" | "Boolean") => new ScalarType({ scal
 
 const col = (name: string, type: CypherType, nullable: boolean): ResolvedColumn => ({ name, type, nullable })
 
-const param = (name: string, type: string): ResolvedParam => ({ name, type }) as ResolvedParam
+const param = (name: string, type: string, nullable = false): ResolvedParam =>
+  ({ name, type, nullable }) as ResolvedParam
 
 // ── Tests ──
 
@@ -180,6 +181,22 @@ describe("analyzeQuery — parameter extraction", () => {
   ])("$label", ({ cypher, expectedParams }) => {
     const result = analyzeQuery(cypher, schema)
     expect(result.params).toEqual(expectedParams)
+  })
+})
+
+describe("analyzeQuery — param nullability", () => {
+  it("marks a param bound to an optional vertex property as nullable", () => {
+    // Method.visibility is optional in the schema fixture
+    const cypher = "MATCH (m:Method {visibility: $vis}) RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([{ name: "vis", type: "String", nullable: true }])
+  })
+
+  it("marks a param bound to a mandatory vertex property as non-nullable", () => {
+    // Method.name is mandatory in the schema fixture
+    const cypher = "MATCH (m:Method {name: $nm}) RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([{ name: "nm", type: "String", nullable: false }])
   })
 })
 

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
@@ -14,6 +14,7 @@ import {
   ReadingStatementContext,
   RelationDetailContext,
   UnwindStContext,
+  UpdatingStatementContext,
   WithStContext
 } from "../internal/generated-parser/CypherParser.js"
 import { type CypherType, EdgeType, UnknownType, VertexType, VertexUnionType } from "../types/CypherType.js"
@@ -203,6 +204,31 @@ function extendEnvFromMatch(env: TypeEnv, matchSt: MatchStContext, schema: Graph
     }
   }
 
+  return newEnv
+}
+
+// Bind variables introduced by CREATE/MERGE patterns. Unlike OPTIONAL MATCH, a
+// created/merged node always exists, so its binding is never nullable. Other
+// updating clauses (DELETE/SET/REMOVE) introduce no new variables.
+function extendEnvFromCreate(env: TypeEnv, updatingSt: UpdatingStatementContext): TypeEnv {
+  const createSt = updatingSt.createSt()
+  const mergeSt = updatingSt.mergeSt()
+
+  const parts = createSt
+    ? createSt.pattern().patternPart()
+    : mergeSt
+    ? [mergeSt.patternPart()]
+    : []
+  if (parts.length === 0) return env
+
+  const newEnv = new Map(env)
+  for (const part of parts) {
+    visitNodePatterns(part, (varName, label) => {
+      if (label) {
+        newEnv.set(varName, { type: new VertexType({ label }), nullable: false })
+      }
+    })
+  }
   return newEnv
 }
 
@@ -640,6 +666,8 @@ export const analyzeQuery = (cypher: string, schema: GraphSchema): QueryAnalysis
         env = extendEnvFromMatch(env, child, schema)
       } else if (child instanceof WithStContext) {
         env = computeEnvFromProjection(child.projectionBody(), env, schema)
+      } else if (child instanceof UpdatingStatementContext) {
+        env = extendEnvFromCreate(env, child)
       }
     }
   }
@@ -652,6 +680,11 @@ export const analyzeQuery = (cypher: string, schema: GraphSchema): QueryAnalysis
       if (matchSt) env = extendEnvFromMatch(env, matchSt, schema)
       const unwindSt = reading.unwindSt()
       if (unwindSt) env = extendEnvFromUnwind(env, unwindSt, schema)
+    }
+    // Updating statements (CREATE/MERGE) follow reading statements in a singlePartQ;
+    // bind their pattern variables so a trailing RETURN can resolve them.
+    for (const updatingSt of single.updatingStatement() ?? []) {
+      env = extendEnvFromCreate(env, updatingSt)
     }
   }
 

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
@@ -62,6 +62,7 @@ export interface ResolvedColumn {
 export interface ResolvedParam {
   readonly name: string
   readonly type: Neo4jType
+  readonly nullable: boolean
 }
 
 /**
@@ -142,14 +143,20 @@ function normalizeNeo4jType(raw: string): Neo4jType {
   }
 }
 
-function lookupParamType(schema: GraphSchema, label: string, propertyName: string): Neo4jType | undefined {
+function lookupParamType(
+  schema: GraphSchema,
+  label: string,
+  propertyName: string
+): { type: Neo4jType; nullable: boolean } | undefined {
   const prop = schema.vertexProperties.find(
     (p) => p.labels.includes(label) && p.propertyName === propertyName
   )
   if (!prop) return undefined
   const rawType = prop.propertyTypes[0]
   if (!rawType) return undefined
-  return normalizeNeo4jType(rawType)
+  // An optional vertex property accepts null (e.g. to clear it), so a param
+  // bound to it must allow null too — matching the RETURN-row NullOr treatment.
+  return { type: normalizeNeo4jType(rawType), nullable: !prop.mandatory }
 }
 
 function scalarToArrayType(scalar: Neo4jType): Neo4jType {
@@ -628,12 +635,20 @@ function extractParams(tree: ReturnType<typeof parse>, schema: GraphSchema): Arr
 
   return paramUsages.map((usage) => {
     if (usage.label && usage.property) {
-      const type = lookupParamType(schema, usage.label, usage.property)
-      if (type) {
-        return { name: usage.paramName, type: usage.isInClause ? scalarToArrayType(type) : type }
+      const resolved = lookupParamType(schema, usage.label, usage.property)
+      if (resolved) {
+        // IN-clause params are arrays of values, not the property itself, so they
+        // are never nullable regardless of the property's optionality.
+        return usage.isInClause
+          ? { name: usage.paramName, type: scalarToArrayType(resolved.type), nullable: false }
+          : { name: usage.paramName, type: resolved.type, nullable: resolved.nullable }
       }
     }
-    return { name: usage.paramName, type: (usage.isInClause ? "StringArray" : "String") as Neo4jType }
+    return {
+      name: usage.paramName,
+      type: (usage.isInClause ? "StringArray" : "String") as Neo4jType,
+      nullable: false
+    }
   })
 }
 

--- a/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
+++ b/packages/cypher-codegen/src/internal/cli/commands/Shared.ts
@@ -127,7 +127,7 @@ function mergeParams(analyzerParams: ReadonlyArray<ResolvedParam>, cypher: strin
   const regexNames = extractParams(cypher)
   const byName = new Map(analyzerParams.map((p) => [p.name, p]))
   for (const name of regexNames) {
-    if (!byName.has(name)) byName.set(name, { name, type: "String" })
+    if (!byName.has(name)) byName.set(name, { name, type: "String", nullable: false })
   }
   return regexNames.filter((n) => byName.has(n)).map((n) => byName.get(n)!)
 }


### PR DESCRIPTION
## Summary

Teaches the Cypher type checker (`@evryg/effect-cypher-codegen`) to handle mutation queries and improves parameter typing. Three independent, additive fixes — no API renamed or removed.

## Changes

- **Bind `CREATE`/`MERGE` pattern variables into the type env.** `analyzeQuery` previously built its environment from reading clauses only (`MATCH`/`UNWIND`/`WITH`), so a `RETURN` referencing a created/merged node threw `CypherTypeError: Unbound variable`. Added `extendEnvFromCreate` (mirrors `extendEnvFromMatch`, reuses `visitNodePatterns`) and wired it into both the `multiPartQ` and `singlePartQ` walks in clause order. Created/merged nodes are non-nullable, so `CREATE (r:Repo {...}) RETURN r.id AS id` now resolves column types from the schema.
- **Emit `T | null` for params bound to optional vertex properties.** Such a param was typed as the bare scalar (e.g. `string`) while the same property on the `RETURN` side is `NullOr` — inconsistent, and callers couldn't pass `null` to clear it. `ResolvedParam` now carries `nullable` (`lookupParamType` returns `{ type, nullable: !mandatory }`); both the barrel and declaration backends append `| null`. `IN`-clause params stay non-nullable (they're arrays of values, not the property itself).
- **Infer bare parameter atoms in projections.** `RETURN $id AS id` threw `Unhandled atom expression`; `inferAtomType` now resolves a parameter atom to a `String` scalar.

## Testing

- TDD throughout: each fix added failing unit tests first (verified they failed for the right reason), then the implementation.
- All **174** unit tests pass (`*.node.unit.test.ts` across `frontend/` and `backend/`); `tsc -b` (typecheck) clean.
- Note: the `*.node.integration.test.ts` suite requires Docker (neo4j testcontainer) and was not run locally; it runs in CI (and at publish time via `changeset-publish`).

## Release

Includes a changeset declaring a **minor** bump for `@evryg/effect-cypher-codegen` (0.1.1 → 0.2.0). Merging this PR lets the Release workflow open the "Version Packages" PR, which updates `CHANGELOG.md` and publishes on merge.

Generated with AI