### PR TITLE
cypher-codegen: infer nullability for SET-clause params

### DIFF
--- a/.changeset/cypher-set-param-nullability.md
+++ b/.changeset/cypher-set-param-nullability.md
@@ -1,0 +1,7 @@
+---
+"@evryg/effect-cypher-codegen": minor
+---
+
+Infer parameter nullability for `SET` clauses
+
+`QueryAnalyzer` now types parameters bound via a `SET` clause (`MATCH (n:Label {...}) SET n.prop = $param`), in addition to node-pattern property maps and `IN` list expressions. A param assigned to an optional vertex property is typed `T | null` (so callers can pass `null` to clear it), while one assigned to a mandatory property stays non-nullable. Map-merge assignments (`SET n += $map`) are unaffected, and params whose left-hand side cannot be resolved to a schema property keep the previous non-nullable `String` fallback.

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.node.unit.test.ts
@@ -200,6 +200,45 @@ describe("analyzeQuery — param nullability", () => {
   })
 })
 
+describe("analyzeQuery — SET-clause param nullability", () => {
+  it("marks a SET param bound to an optional vertex property as nullable", () => {
+    // Method.visibility is optional in the schema fixture
+    const cypher = "MATCH (m:Method {id: $id}) SET m.visibility = $vis RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([
+      { name: "id", type: "String", nullable: false },
+      { name: "vis", type: "String", nullable: true }
+    ])
+  })
+
+  it("marks a SET param bound to a mandatory vertex property as non-nullable", () => {
+    // Method.name is mandatory in the schema fixture
+    const cypher = "MATCH (m:Method {id: $id}) SET m.name = $nm RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([
+      { name: "id", type: "String", nullable: false },
+      { name: "nm", type: "String", nullable: false }
+    ])
+  })
+
+  it("types each item of a multi-property SET independently", () => {
+    const cypher = "MATCH (m:Method {id: $id}) SET m.visibility = $vis, m.name = $nm RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([
+      { name: "id", type: "String", nullable: false },
+      { name: "vis", type: "String", nullable: true },
+      { name: "nm", type: "String", nullable: false }
+    ])
+  })
+
+  it("does not double-count a param constrained in both a MATCH pattern and a SET", () => {
+    // Method.visibility is optional → nullable, and appears once despite two usages
+    const cypher = "MATCH (m:Method {visibility: $v}) SET m.visibility = $v RETURN m.id AS id"
+    const result = analyzeQuery(cypher, schema)
+    expect(result.params).toEqual([{ name: "v", type: "String", nullable: true }])
+  })
+})
+
 describe("analyzeQuery — WITH rebinding", () => {
   it("tracks variables through WITH clause", () => {
     const cypher = `MATCH (c:Class)

--- a/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
+++ b/packages/cypher-codegen/src/frontend/QueryAnalyzer.ts
@@ -13,6 +13,7 @@ import {
   PatternElemContext,
   ReadingStatementContext,
   RelationDetailContext,
+  SetItemContext,
   UnwindStContext,
   UpdatingStatementContext,
   WithStContext
@@ -631,6 +632,34 @@ function extractParams(tree: ReturnType<typeof parse>, schema: GraphSchema): Arr
     const property = lhsText.slice(dotIdx + 1)
     const label = varLabels.get(varName)
     paramUsages.push({ paramName, label, property, isInClause: true })
+  })
+
+  // Pass 3: Walk SET items of the form `<var>.<prop> = $param`, mirroring Pass 1.
+  // Only the `propertyExpression ASSIGN expression` alternative is handled; `SET r += $map`
+  // (map-merge) uses the `symbol ADD_ASSIGN expression` alternative, whose propertyExpression()
+  // is null, so it is naturally excluded — that map param is a separate feature.
+  walkTree(tree, SetItemContext, (item) => {
+    const propExpr = item.propertyExpression()
+    if (!propExpr) return
+
+    // LHS must be a simple `var.prop` (single property segment).
+    const names = propExpr.name()
+    if (names.length !== 1) return
+    const varName = propExpr.atom().getText()
+    const property = names[0]!.getText()
+
+    const expr = item.expression()
+    if (!expr) return
+    const paramCtx = findParameter(expr)
+    if (!paramCtx) return
+    const paramSym = paramCtx.symbol()
+    if (!paramSym) return
+    const paramName = paramSym.getText()
+    if (seenParams.has(paramName)) return
+    seenParams.add(paramName)
+
+    const label = varLabels.get(varName)
+    paramUsages.push({ paramName, label, property })
   })
 
   return paramUsages.map((usage) => {


### PR DESCRIPTION
## Problem

`QueryAnalyzer.extractParams` typed query parameters from two sources only:

1. **Pass 1** — params inside node-pattern property maps: `(n:Label {prop: $p})` (covers `CREATE`/`MATCH` constraints).
2. **Pass 2** — `expr.prop IN $param` list expressions.

Params bound via a `SET` clause — `MATCH (n:Label {id: $id}) SET n.prop = $p` — were **not** analyzed. The backend regex scan still surfaced the param *name*, so it appeared in the generated signature, but with the fallback type `{ type: "String", nullable: false }`.

Net effect: a param assigned to an **optional** vertex property was typed non-nullable (e.g. `prop: string`) when it should be `prop: string | null` — the adapter must be able to persist `null` to clear such a property.

## Fix

Add a **Pass 3** to `extractParams`, mirroring Pass 1 but walking `SET` items:

- Walks `SetItemContext` nodes, handling only the `propertyExpression ASSIGN expression` alternative (`<var>.<prop> = $param`).
- Resolves `<var>` → label via the existing `buildVarLabelMap`, then types the param via `lookupParamType` exactly as Pass 1 does — emitting the property's `type` and `nullable` flag.
- `SET n += $map` (map-merge) is naturally excluded: that alternative has no `propertyExpression()`, so it never enters Pass 3 (map params remain a separate feature).
- The shared `seenParams` set prevents double-counting a param used in both a pattern and a `SET`.
- Left-hand sides that can't be resolved to a labelled schema property keep the prior non-nullable `String` fallback, so behaviour is unchanged for untyped params.

## Tests

New `describe("analyzeQuery — SET-clause param nullability")` block in `QueryAnalyzer.node.unit.test.ts`, written test-first (verified red for the right reason — SET params were absent from analyzer output — before implementing):

- SET param on an **optional** vertex property → `nullable: true`.
- SET param on a **mandatory** vertex property → `nullable: false`.
- Multi-property `SET` types each item independently.
- A param constrained in both a `MATCH` pattern and a `SET` is not double-counted.

Existing Pass 1 (`CREATE`/`MATCH`) and Pass 2 (`IN`) param typing is unchanged. Full package unit suite: 178/178 green; `pnpm check` clean.

## Release

Changeset included: **minor** bump for `@evryg/effect-cypher-codegen` (`0.2.0` → `0.3.0`).

## Commits

- `cypher-codegen: infer nullability for SET-clause params` — Pass 3 implementation + unit tests
- `cypher-codegen: changeset for SET-clause param nullability` — release changeset
